### PR TITLE
Upgrade to wasa-sdk-21 (LLVM 17); Upgrade windows native to MinGW-w64 11.0.1 (UCRT)

### DIFF
--- a/src/icpp/canisters/greet/demo.ps1
+++ b/src/icpp/canisters/greet/demo.ps1
@@ -78,16 +78,16 @@ Write-Host "--------------------------------------------------"
 Write-Host "Stopping the local network in wsl"
 wsl dfx stop
 
-# Native build on Windows is temporarily broken..
-# #######################################################################
-# Write-Host " "
-# Write-Host "--------------------------------------------------"
-# Write-Host "Building the Windows native debug executable with clang++"
-# icpp build-native --to-compile all
-# # icpp build-native --to-compile mine
+Native build on Windows is temporarily broken..
+#######################################################################
+Write-Host " "
+Write-Host "--------------------------------------------------"
+Write-Host "Building the Windows native debug executable with clang++"
+icpp build-native --to-compile all
+# icpp build-native --to-compile mine
 
-# #######################################################################
-# Write-Host " "
-# Write-Host "--------------------------------------------------"
-# Write-Host "Running the Windows native debug executable"
-# .\build-native\mockic.exe
+#######################################################################
+Write-Host " "
+Write-Host "--------------------------------------------------"
+Write-Host "Running the Windows native debug executable"
+.\build-native\mockic.exe

--- a/src/icpp/version_wasi_sdk.py
+++ b/src/icpp/version_wasi_sdk.py
@@ -5,4 +5,4 @@ Defines the version for the compatible wasi-sdk compiler.
 (-) do not add anything but the version number of the wasi-sdk compiler here!
 
 """
-__version__ = "wasi-sdk-20.0"
+__version__ = "wasi-sdk-21.0"

--- a/test/canisters/canister_1/demo.ps1
+++ b/test/canisters/canister_1/demo.ps1
@@ -78,18 +78,18 @@ Write-Host "--------------------------------------------------"
 Write-Host "Stopping the local network in wsl"
 wsl dfx stop
 
-# #######################################################################
-# # Since release 3.6.0, the Native build is broken on Windows.
-# # Most likely due to a compiler limitation.
-# #
-# Write-Host " "
-# Write-Host "--------------------------------------------------"
-# Write-Host "Building the Windows native debug executable with clang++"
-# icpp build-native --to-compile all
-# # icpp build-native --to-compile mine
+#######################################################################
+# Since release 3.6.0, the Native build is broken on Windows.
+# Most likely due to a compiler limitation.
+#
+Write-Host " "
+Write-Host "--------------------------------------------------"
+Write-Host "Building the Windows native debug executable with clang++"
+icpp build-native --to-compile all
+# icpp build-native --to-compile mine
 
-# #######################################################################
-# Write-Host " "
-# Write-Host "--------------------------------------------------"
-# Write-Host "Running the Windows native debug executable"
-# .\build-native\mockic.exe
+#######################################################################
+Write-Host " "
+Write-Host "--------------------------------------------------"
+Write-Host "Running the Windows native debug executable"
+.\build-native\mockic.exe


### PR DESCRIPTION
The upgrade to wasa-sdk-21 did not require any modifications. Just had to bump the version number and everything else worked as is.

Make sure to use the latest dfx version. I tested with 0.15 and 0.16.

**build-native** is fixed on **Windows** !!!
=> Update your mingw installation for the Clang++ compiler to MinGW-w64 11.0.1 (UCRT)
=> See [installation for windows](https://docs.icpp.world/installation.html#windows_2)