### PR TITLE
[[noreturn]] attribute to ic api trap

### DIFF
--- a/src/icpp/ic/ic0/ic0.h
+++ b/src/icpp/ic/ic0/ic0.h
@@ -101,7 +101,8 @@ uint32_t ic0_is_controller(uint32_t src, uint32_t size)
 void ic0_debug_print(uint32_t src, uint32_t size)
     WASM_SYMBOL_IMPORTED("ic0", "debug_print");
 
-[[noreturn]] void ic0_trap(uint32_t src, uint32_t size) WASM_SYMBOL_IMPORTED("ic0", "trap");
+[[noreturn]] void ic0_trap(uint32_t src, uint32_t size)
+    WASM_SYMBOL_IMPORTED("ic0", "trap");
 
 #ifdef __cplusplus
 }

--- a/src/icpp/ic/ic0/ic0.h
+++ b/src/icpp/ic/ic0/ic0.h
@@ -101,7 +101,7 @@ uint32_t ic0_is_controller(uint32_t src, uint32_t size)
 void ic0_debug_print(uint32_t src, uint32_t size)
     WASM_SYMBOL_IMPORTED("ic0", "debug_print");
 
-void ic0_trap(uint32_t src, uint32_t size) WASM_SYMBOL_IMPORTED("ic0", "trap");
+[[noreturn]] void ic0_trap(uint32_t src, uint32_t size) WASM_SYMBOL_IMPORTED("ic0", "trap");
 
 #ifdef __cplusplus
 }

--- a/src/icpp/ic/ic0mock/ic0.h
+++ b/src/icpp/ic/ic0mock/ic0.h
@@ -72,7 +72,7 @@ uint32_t ic0_is_controller(uintptr_t src, uint32_t size);
 
 void ic0_debug_print(uintptr_t src, uint32_t size);
 
-void ic0_trap(uintptr_t src, uint32_t size);
+[[noreturn]] void ic0_trap(uintptr_t src, uint32_t size);
 
 #ifdef __cplusplus
 }

--- a/src/icpp/ic/icapi/ic_api.h
+++ b/src/icpp/ic/icapi/ic_api.h
@@ -43,8 +43,8 @@ public:
   static void debug_print(const std::string &msg); // docs end: demo_debug_print
 
   // docs start: demo_trap
-  static void trap(const char *msg);
-  static void trap(const std::string &msg); // docs end: demo_trap
+  [[noreturn]] static void trap(const char *msg);
+  [[noreturn]] static void trap(const std::string &msg); // docs end: demo_trap
 
   // docs start: demo_time
   static uint64_t time(); // docs end: demo_time


### PR DESCRIPTION
This avoids compiler warnings when you trap a function that expects a return value.