### PR TITLE
Upgrade rust to 1.86.0

### DIFF
--- a/src/icpp/commands_install_rust.py
+++ b/src/icpp/commands_install_rust.py
@@ -36,7 +36,9 @@ def install_rustup(nstep: int, num_steps: int) -> None:
 
 def install_wasm32_wasip1(nstep: int, num_steps: int) -> None:
     """Installs rust wasm32-wasip1 target into user's icpp folder"""
-    typer.echo(f"- {nstep}/{num_steps} Installing wasm32-wasip1 target for rust compiler")
+    typer.echo(
+        f"- {nstep}/{num_steps} Installing wasm32-wasip1 target for rust compiler"
+    )
     cmd = f"{config_default.RUSTUP} target add wasm32-wasip1 "
     run_shell_cmd_with_log(LOG_FILE, "a", cmd, timeout_seconds=TIMEOUT_SECONDS)
 

--- a/src/icpp/commands_install_rust.py
+++ b/src/icpp/commands_install_rust.py
@@ -34,10 +34,10 @@ def install_rustup(nstep: int, num_steps: int) -> None:
     run_shell_cmd_with_log(LOG_FILE, "w", cmd, timeout_seconds=TIMEOUT_SECONDS)
 
 
-def install_wasm32_wasi(nstep: int, num_steps: int) -> None:
-    """Installs rust wasm32-wasi target into user's icpp folder"""
-    typer.echo(f"- {nstep}/{num_steps} Installing wasm32-wasi target for rust compiler")
-    cmd = f"{config_default.RUSTUP} target add wasm32-wasi "
+def install_wasm32_wasip1(nstep: int, num_steps: int) -> None:
+    """Installs rust wasm32-wasip1 target into user's icpp folder"""
+    typer.echo(f"- {nstep}/{num_steps} Installing wasm32-wasip1 target for rust compiler")
+    cmd = f"{config_default.RUSTUP} target add wasm32-wasip1 "
     run_shell_cmd_with_log(LOG_FILE, "a", cmd, timeout_seconds=TIMEOUT_SECONDS)
 
 
@@ -102,7 +102,7 @@ def install_ic_wasi_polyfill(nstep: int, num_steps: int) -> None:
         timeout_seconds=TIMEOUT_SECONDS,
     )
 
-    cmd = f"{config_default.CARGO} build --release --target wasm32-wasi "
+    cmd = f"{config_default.CARGO} build --release --target wasm32-wasip1 "
 
     #
     # The 'transient' feature use the transient file system implementation.
@@ -150,7 +150,7 @@ def install_rust() -> None:
         install_rustup(nstep, num_steps)
         nstep += 1
 
-        install_wasm32_wasi(nstep, num_steps)
+        install_wasm32_wasip1(nstep, num_steps)
         nstep += 1
 
         install_wasi2ic(nstep, num_steps)

--- a/src/icpp/config_default.py
+++ b/src/icpp/config_default.py
@@ -28,7 +28,7 @@ WASI_SDK_COMPILER_ROOT = WASI_SDK_ROOT / f"{__version_wasi_sdk__}"
 RUST_ROOT = ICPP_ROOT / "rust"
 RUST_COMPILER_ROOT = RUST_ROOT / f"{__version_rust__}"
 RUST_BIN = RUST_COMPILER_ROOT / "bin"
-RUST_TARGET = RUST_COMPILER_ROOT / "target/wasm32-wasi/release"
+RUST_TARGET = RUST_COMPILER_ROOT / "target/wasm32-wasip1/release"
 
 CARGO = RUST_BIN / "cargo"
 # CARGO_BINSTALL = RUST_BIN / "cargo-binstall"  # Not using this yet...

--- a/src/icpp/version_rust.py
+++ b/src/icpp/version_rust.py
@@ -6,4 +6,4 @@ Defines the version for the compatible rust compiler.
 
 """
 
-__version__ = "1.79.0"
+__version__ = "1.86.0"


### PR DESCRIPTION
https://github.com/icppWorld/icpp-pro/issues/31

`icpp install-rustc` stopped working due to this rust package:

```
error: rustc 1.79.0 is not supported by the following package:
  half@2.5.0 requires rustc 1.81
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.79.0
```