### PR TITLE
Add IC_API timer support and canister_timers test canister

### DIFF
--- a/.github/workflows/cicd-mac.yml
+++ b/.github/workflows/cicd-mac.yml
@@ -15,7 +15,9 @@ jobs:
     name: all-mac
     strategy:
       matrix:
-        python-version: [3.9, 3.11]
+        # NOTE: Python versions MUST be quoted strings — unquoted 3.10 is
+        # parsed by YAML as the float 3.1 and breaks actions/setup-python.
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         # macos-15-intel for Intel, macos-latest for Apple Silicon arm64
         os: [macos-15-intel, macos-latest]
 

--- a/.github/workflows/cicd-mac.yml
+++ b/.github/workflows/cicd-mac.yml
@@ -14,6 +14,11 @@ jobs:
   all-mac:
     name: all-mac
     strategy:
+      # Don't cancel the whole matrix when one cell flakes (e.g. transient
+      # DNS resolution failures hitting index.crates.io during install-rust
+      # on macos-15-intel). Each (python-version, os) pair stands or falls
+      # on its own and is rerun-able independently from the GitHub UI.
+      fail-fast: false
       matrix:
         # NOTE: Python versions MUST be quoted strings — unquoted 3.10 is
         # parsed by YAML as the float 3.1 and breaks actions/setup-python.
@@ -89,6 +94,13 @@ jobs:
 
       - name: install-rust
         shell: bash -l {0}
+        # Cargo's default network retry is 3 attempts. macos-15-intel
+        # runners have shown longer-than-3-attempt DNS resolution flakes
+        # against index.crates.io. Bump retry count and request timeout
+        # so transient hiccups don't take the cell down.
+        env:
+          CARGO_NET_RETRY: "10"
+          CARGO_HTTP_TIMEOUT: "60"
         run: |
           echo "Installing rust"
           icpp install-rust

--- a/.github/workflows/cicd-mac.yml
+++ b/.github/workflows/cicd-mac.yml
@@ -28,6 +28,14 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
+          # Python 3.14 (and often the newest 3.x line generally) is not
+          # in conda's `defaults` channel for every (os, arch) combo —
+          # macos-15-intel + python=3.14 in particular fails with
+          # PackagesNotFoundError. conda-forge tracks new Python releases
+          # faster, so prefer it. `channel-priority: strict` keeps the
+          # solver predictable across versions.
+          channels: conda-forge,defaults
+          channel-priority: strict
 
       # -------------------------------------------------------------------
       # Checkout icpp-pro & icpp-candid as nested directory

--- a/.github/workflows/cicd-ubuntu.yml
+++ b/.github/workflows/cicd-ubuntu.yml
@@ -27,6 +27,12 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
+          # Python 3.14 (and often the newest 3.x line generally) is not
+          # in conda's `defaults` channel for every (os, arch) combo —
+          # conda-forge tracks new Python releases faster, so prefer it.
+          # `channel-priority: strict` keeps the solver predictable.
+          channels: conda-forge,defaults
+          channel-priority: strict
 
       # -------------------------------------------------------------------
       # Checkout icpp-pro & icpp-candid as nested directory

--- a/.github/workflows/cicd-ubuntu.yml
+++ b/.github/workflows/cicd-ubuntu.yml
@@ -14,6 +14,9 @@ jobs:
   all-ubuntu:
     name: all-ubuntu
     strategy:
+      # Don't cancel the whole matrix when one cell flakes — see comment
+      # in cicd-mac.yml. Each cell stands or falls on its own.
+      fail-fast: false
       matrix:
         # NOTE: Python versions MUST be quoted strings — unquoted 3.10 is
         # parsed by YAML as the float 3.1 and breaks actions/setup-python.
@@ -88,6 +91,11 @@ jobs:
 
       - name: install-rust
         shell: bash -l {0}
+        # Bump cargo's default network-retry from 3 to 10 to weather
+        # transient DNS / index.crates.io hiccups on the runner.
+        env:
+          CARGO_NET_RETRY: "10"
+          CARGO_HTTP_TIMEOUT: "60"
         run: |
           echo "Installing rust"
           icpp install-rust

--- a/.github/workflows/cicd-ubuntu.yml
+++ b/.github/workflows/cicd-ubuntu.yml
@@ -15,7 +15,9 @@ jobs:
     name: all-ubuntu
     strategy:
       matrix:
-        python-version: [3.9, 3.11]
+        # NOTE: Python versions MUST be quoted strings — unquoted 3.10 is
+        # parsed by YAML as the float 3.1 and breaks actions/setup-python.
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.pylintrc
+++ b/.pylintrc
@@ -79,92 +79,36 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        import-star-module-level,
-        non-ascii-bytes-literal,
-        raw-checker-failed,
+disable=raw-checker-failed,
         bad-inline-option,
         locally-disabled,
-        locally-enabled,
         file-ignored,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
         use-symbolic-message-instead,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        deprecated-string-function,
-        deprecated-str-translate-call,
-        deprecated-itertools-function,
-        deprecated-types-field,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
-        deprecated-operator-function,
-        deprecated-urllib-function,
-        xreadlines-attribute,
-        deprecated-sys-function,
-        exception-escape,
-        comprehension-escape,
-        bare-except, too-many-arguments, too-many-instance-attributes,
-        too-many-branches, too-many-locals, 
-        bad-continuation, bad-whitespace,
+        bare-except,
+        too-many-arguments,
+        too-many-positional-arguments,
+        too-many-instance-attributes,
+        too-many-branches,
+        too-many-locals,
+        too-many-statements,
         logging-fstring-interpolation,
-        duplicate-code, fixme
-#ICPP: I started adding with 'bare-except'
+        duplicate-code,
+        fixme,
+        cyclic-import
+# Notes:
+#  - The earlier disable list contained dozens of Python-2-to-3 transition
+#    checks (e.g. print-statement, basestring-builtin, dict-iter-method).
+#    Those checkers were removed in pylint 3.x; leaving them in the disable
+#    list produces useless-option-value warnings.
+#  - 'cyclic-import' is disabled because the icpp.__main__ → commands_*
+#    → decorators chain forms a cycle that pylint 3.x detects more
+#    aggressively than 2.x; refactoring it is out of scope for the lint
+#    bump that ships with the Python 3.10–3.14 matrix update.
+#  - The 'no-space-check' option was removed by pylint 3.x as well; it
+#    was elsewhere in this file and has been deleted.
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -473,12 +417,9 @@ max-line-length=89
 # Maximum number of lines in a module.
 max-module-lines=2000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
+# Note: the 'no-space-check' option (which used to live here, configuring
+# `trailing-comma` and `dict-separator`) was removed in pylint 3.x because
+# whitespace checks themselves were dropped in favor of black formatting.
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
@@ -582,4 +523,4 @@ min-public-methods=2
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception".
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,12 @@ install-python:
 	# `python` is the conda env's interpreter — installs land in the wrong
 	# site-packages and `import icpp_candid` later fails. `python -m pip`
 	# is always the active interpreter's pip.
+	#
+	# `ensurepip` first: conda envs created via setup-miniconda with
+	# channel-priority=strict do NOT include pip by default, so the very
+	# first `python -m pip` would fail with "No module named pip".
+	# ensurepip is stdlib (no network) and bootstraps the bundled pip.
+	python -m ensurepip --upgrade
 	python -m pip install --upgrade pip
 	cd icpp-candid && rm -rf src/*.egg-info && python -m pip install -e ".[dev]"
 	rm -rf src/*.egg-info
@@ -236,7 +242,8 @@ install-python:
 
 .PHONY: install-python-w-demos
 install-python-w-demos:
-	# See the install-python comment above for why `python -m pip`.
+	# See the install-python comment above for `ensurepip` and `python -m pip`.
+	python -m ensurepip --upgrade
 	python -m pip install --upgrade pip
 	cd icpp-candid && rm -rf src/*.egg-info && python -m pip install -e ".[dev]"
 	rm -rf src/*.egg-info
@@ -246,6 +253,7 @@ install-python-w-demos:
 
 .PHONY: install-python-w-icpp-llm
 install-python-w-icpp-llm:
+	python -m ensurepip --upgrade
 	python -m pip install --upgrade pip
 	cd icpp-candid && rm -rf src/*.egg-info && python -m pip install -e ".[dev]"
 	rm -rf src/*.egg-info
@@ -254,6 +262,7 @@ install-python-w-icpp-llm:
 
 .PHONY: install-python-w-llama_cpp_canister
 install-python-w-llama_cpp_canister:
+	python -m ensurepip --upgrade
 	python -m pip install --upgrade pip
 	cd icpp-candid && rm -rf src/*.egg-info && python -m pip install -e ".[dev]"
 	rm -rf src/*.egg-info

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,19 @@ VERSION_CLANG := $(shell cat version_clang.txt)
 
 ###########################################################################
 # Use some clang tools that come with wasi-sdk
+#
+# WASI_SDK_COMPILER_VERSION is read directly from the small version_wasi_sdk
+# module (no transitive imports). WASI_SDK_COMPILER_ROOT is then constructed
+# the same way config_default.py does it (~/.icpp/wasi-sdk/<version>).
+#
+# We deliberately do NOT import config_default for this — that module imports
+# icpp_candid, which is not yet installed at the time `make install-python`
+# parses the Makefile, and on CI runners where pip and python resolve to
+# different interpreters (a system Python 3.14 at /Library/Frameworks vs the
+# conda env's Python 3.13) it can stay broken even after install. Computing
+# the path in pure Make keeps `make` self-bootstrapping.
 WASI_SDK_COMPILER_VERSION := $(shell python -c "import sys; sys.path.append('src'); from src.icpp.version_wasi_sdk import __version__; print(__version__)")
-WASI_SDK_COMPILER_ROOT := $(shell python -c "import sys; sys.path.append('src'); from src.icpp.config_default import WASI_SDK_COMPILER_ROOT; print(WASI_SDK_COMPILER_ROOT)")
+WASI_SDK_COMPILER_ROOT := $(HOME)/.icpp/wasi-sdk/$(WASI_SDK_COMPILER_VERSION)
 CLANG_FORMAT = $(WASI_SDK_COMPILER_ROOT)/bin/clang-format
 CLANG_TIDY = $(WASI_SDK_COMPILER_ROOT)/bin/clang-tidy
 
@@ -212,35 +223,42 @@ install-homebrew-mac:
 
 .PHONY: install-python
 install-python:
-	pip install --upgrade pip
-	cd icpp-candid && rm -rf src/*.egg-info && pip install -e ".[dev]"
+	# Use `python -m pip` rather than `pip`. On GitHub macOS runners the
+	# bare `pip` can resolve to a system Python framework (e.g.
+	# /Library/Frameworks/Python.framework/.../pip for Python 3.14) while
+	# `python` is the conda env's interpreter — installs land in the wrong
+	# site-packages and `import icpp_candid` later fails. `python -m pip`
+	# is always the active interpreter's pip.
+	python -m pip install --upgrade pip
+	cd icpp-candid && rm -rf src/*.egg-info && python -m pip install -e ".[dev]"
 	rm -rf src/*.egg-info
-	pip install -e ".[dev]"
+	python -m pip install -e ".[dev]"
 
 .PHONY: install-python-w-demos
 install-python-w-demos:
-	pip install --upgrade pip
-	cd icpp-candid && rm -rf src/*.egg-info && pip install -e ".[dev]"
+	# See the install-python comment above for why `python -m pip`.
+	python -m pip install --upgrade pip
+	cd icpp-candid && rm -rf src/*.egg-info && python -m pip install -e ".[dev]"
 	rm -rf src/*.egg-info
-	pip install -e ".[dev]"
-	cd ../icpp-demos && pip install -r requirements.txt
+	python -m pip install -e ".[dev]"
+	cd ../icpp-demos && python -m pip install -r requirements.txt
 
 
 .PHONY: install-python-w-icpp-llm
 install-python-w-icpp-llm:
-	pip install --upgrade pip
-	cd icpp-candid && rm -rf src/*.egg-info && pip install -e ".[dev]"
+	python -m pip install --upgrade pip
+	cd icpp-candid && rm -rf src/*.egg-info && python -m pip install -e ".[dev]"
 	rm -rf src/*.egg-info
-	pip install -e ".[dev]"
-	cd ../icpp_llm && pip install -r requirements.txt
+	python -m pip install -e ".[dev]"
+	cd ../icpp_llm && python -m pip install -r requirements.txt
 
 .PHONY: install-python-w-llama_cpp_canister
 install-python-w-llama_cpp_canister:
-	pip install --upgrade pip
-	cd icpp-candid && rm -rf src/*.egg-info && pip install -e ".[dev]"
+	python -m pip install --upgrade pip
+	cd icpp-candid && rm -rf src/*.egg-info && python -m pip install -e ".[dev]"
 	rm -rf src/*.egg-info
-	pip install -e ".[dev]"
-	cd ../llama_cpp_canister && pip install -r requirements.txt
+	python -m pip install -e ".[dev]"
+	cd ../llama_cpp_canister && python -m pip install -r requirements.txt
 
 # .PHONY:install-rust
 # install-rust:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 name = "icpp-pro"
 description = "C++ Canister Development Kit (CDK) for the Internet Computer"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "icpp-pro", email = "icpp@icpp.world" }]
 maintainers = [{ name = "icpp-pro", email = "icpp@icpp.world" }]
 license = { file = "LICENSE" }
@@ -37,10 +37,11 @@ classifiers = [
     # that you indicate you support Python 3. These classifiers are *not*
     # checked by 'pip install'. See instead 'python_requires' below.
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     # NOTE: Windows is not supported
     "Operating System :: POSIX :: Linux",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,14 @@ icpp = "icpp.__main__:main"
 
 [project.optional-dependencies]
 dev = [
-    "black==23.12.1",
-    "pylint==2.13.9",
-    "mypy==1.8.0",
+    # Bumped from black==23.12.1 / pylint==2.13.9 / mypy==1.8.0 to
+    # versions that handle Python 3.12+ syntax (PEP 695 `type X = ...`).
+    # Older pylint+astroid crashed with
+    #   AttributeError: 'TreeRebuilder' object has no attribute 'visit_typealias'
+    # the moment any imported module used the new syntax.
+    "black==24.10.0",
+    "pylint==3.3.4",
+    "mypy==1.13.0",
     "build==1.2.2",
     "twine==6.0.1",
     "mkdocs==1.5.3",

--- a/src/icpp/commands_install_rust.py
+++ b/src/icpp/commands_install_rust.py
@@ -3,13 +3,12 @@
 import sys
 import platform
 import subprocess
-import shutil
 import typer
 from icpp.__main__ import app
 from icpp import config_default
 from icpp import __version_rust__, __version_ic_wasi_polyfill__, __version_wasi2ic__
 from icpp.run_shell_cmd import run_shell_cmd_with_log
-from icpp.utils import remove_readonly
+from icpp.utils import rmtree_force
 
 OS_SYSTEM = platform.system()
 OS_PROCESSOR = platform.processor()
@@ -143,7 +142,7 @@ def install_rust() -> None:
     typer.echo(f"Details in {LOG_FILE}")
 
     try:
-        shutil.rmtree(config_default.RUST_COMPILER_ROOT, onerror=remove_readonly)
+        rmtree_force(config_default.RUST_COMPILER_ROOT)
     except FileNotFoundError:
         pass
     except OSError as e:

--- a/src/icpp/commands_install_wasi_sdk.py
+++ b/src/icpp/commands_install_wasi_sdk.py
@@ -139,12 +139,15 @@ def install_wasi_sdk() -> None:
                 progress_bar_manager = enlighten.get_manager()
                 dlen = int(r.headers.get("Content-Length", "0")) or None
 
-                with progress_bar_manager.counter(
-                    color="cyan",
-                    total=dlen and math.ceil(dlen / 2**20),
-                    unit="MiB",
-                    leave=False,
-                ) as ctr, open(fpath, "wb", buffering=2**24) as f:
+                with (
+                    progress_bar_manager.counter(
+                        color="cyan",
+                        total=dlen and math.ceil(dlen / 2**20),
+                        unit="MiB",
+                        leave=False,
+                    ) as ctr,
+                    open(fpath, "wb", buffering=2**24) as f,
+                ):
                     for chunk in r.iter_content(chunk_size=2**20):
                         # print(chunk[-16:].hex().upper())
                         f.write(chunk)

--- a/src/icpp/config_default.py
+++ b/src/icpp/config_default.py
@@ -130,6 +130,11 @@ WASM_CPPFLAGS = WASM_CFLAGS
 WASM_LDFLAGS = (
     " -mexec-model=reactor "
     " -Wl,--lto-O3 -Wl,--strip-debug -Wl,--stack-first -Wl,--export-dynamic "
+    # Force the built-in canister_global_timer dispatcher to be linked in and
+    # exported. It lives in __ic_candid__.a and would otherwise be dropped
+    # by the WASM linker's archive-selection rules (no caller references it
+    # statically — the IC invokes it at runtime).
+    " -Wl,-u,canister_global_timer -Wl,--export=canister_global_timer "
 )
 WASM_ARFLAGS = "qc"
 WASM_AR_EXT = ".a"

--- a/src/icpp/conftest_base.py
+++ b/src/icpp/conftest_base.py
@@ -37,7 +37,7 @@ def identity() -> Any:
     """A fixture that returns the name of the used identity."""
     identity_ = get_identity()
     if identity_.startswith("ERROR"):
-        raise Exception(identity_)
+        raise RuntimeError(identity_)
     return identity_
 
 
@@ -51,8 +51,8 @@ def principal() -> Any:
                 f"Identity '{get_identity()}' uses a passphrase. "
                 f"Use identity created with '--storage-mode plaintext'!"
             )
-            raise Exception(msg)
-        raise Exception(principal_)
+            raise RuntimeError(msg)
+        raise RuntimeError(principal_)
     return principal_
 
 

--- a/src/icpp/ic/canister/canister_global_timer.h
+++ b/src/icpp/ic/canister/canister_global_timer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "canister_base.h"
+#include "wasm_symbol.h"
 #include <string>
 
 class CanisterGlobalTimer : public CanisterBase {
@@ -9,3 +10,9 @@ public:
   CanisterGlobalTimer(std::string calling_function);
   ~CanisterGlobalTimer();
 };
+
+// Built-in canister_global_timer dispatcher. Drains all due timers from
+// the IcTimers registry and re-arms ic0.global_timer_set. Exported from
+// the WASM canister; also linked into native builds so MockIC drivers
+// can invoke it directly to simulate the IC firing the timer.
+void canister_global_timer() WASM_SYMBOL_EXPORTED("canister_global_timer");

--- a/src/icpp/ic/canister/canister_global_timer_export.cpp
+++ b/src/icpp/ic/canister/canister_global_timer_export.cpp
@@ -2,13 +2,19 @@
 // (with the WASM export attributes) lives in canister_global_timer.h, but
 // we include canister.h here instead so the canister_*.h forward-decl
 // chain is fully resolved (mirrors how canister_global_timer.cpp does it).
+//
+// __attribute__((weak)) on the definition makes this symbol a weak
+// definition so a user-supplied strong canister_global_timer (declared via
+// the same WASM_SYMBOL_EXPORTED macro and defined without weak in the
+// user's translation unit) takes precedence at link time. wasm-ld picks
+// the strong definition; our archive member is then not pulled in.
 
 #include "canister.h"
 
 #include "ic_api.h"
 #include "ic_timers.h"
 
-void canister_global_timer() {
+__attribute__((weak)) void canister_global_timer() {
   IC_API ic_api(CanisterGlobalTimer{std::string(__func__)}, false);
   IcTimers::instance().dispatch_due(IC_API::time());
 }

--- a/src/icpp/ic/canister/canister_global_timer_export.cpp
+++ b/src/icpp/ic/canister/canister_global_timer_export.cpp
@@ -1,0 +1,14 @@
+// Definition of the built-in canister_global_timer entry. The declaration
+// (with the WASM export attributes) lives in canister_global_timer.h, but
+// we include canister.h here instead so the canister_*.h forward-decl
+// chain is fully resolved (mirrors how canister_global_timer.cpp does it).
+
+#include "canister.h"
+
+#include "ic_api.h"
+#include "ic_timers.h"
+
+void canister_global_timer() {
+  IC_API ic_api(CanisterGlobalTimer{std::string(__func__)}, false);
+  IcTimers::instance().dispatch_due(IC_API::time());
+}

--- a/src/icpp/ic/ic0/ic0.h
+++ b/src/icpp/ic/ic0/ic0.h
@@ -95,6 +95,9 @@ void ic0_stable_read(uint32_t dst, uint32_t off, uint32_t size)
 
 uint64_t ic0_time() WASM_SYMBOL_IMPORTED("ic0", "time");
 
+uint64_t ic0_global_timer_set(uint64_t timestamp_ns)
+    WASM_SYMBOL_IMPORTED("ic0", "global_timer_set");
+
 uint32_t ic0_is_controller(uint32_t src, uint32_t size)
     WASM_SYMBOL_IMPORTED("ic0", "is_controller");
 

--- a/src/icpp/ic/ic0mock/ic0.cpp
+++ b/src/icpp/ic/ic0mock/ic0.cpp
@@ -222,6 +222,24 @@ uint64_t ic0_time() {
   return time_in_ns;
 }
 
+// Mock IC does not actually fire timers. Native tests drive
+// canister_global_timer manually via MockIC::run_test. We just record the
+// last armed deadline so tests can introspect / log it, and return the
+// previous value as the IC interface spec requires.
+namespace {
+uint64_t g_mock_armed_global_timer{0};
+} // namespace
+
+uint64_t ic0_global_timer_set(uint64_t timestamp_ns) {
+  uint64_t previous = g_mock_armed_global_timer;
+  g_mock_armed_global_timer = timestamp_ns;
+#if ICPP_VERBOSE > 0
+  std::cout << "ic0mock ic0::global_timer_set -> " << timestamp_ns << " (was "
+            << previous << ")" << std::endl;
+#endif
+  return previous;
+}
+
 uint32_t ic0_is_controller(uintptr_t src, uint32_t size) {
   const uint8_t *p_bytes = reinterpret_cast<const uint8_t *>(src);
   std::vector<uint8_t> bytes(p_bytes, p_bytes + size);

--- a/src/icpp/ic/ic0mock/ic0.cpp
+++ b/src/icpp/ic/ic0mock/ic0.cpp
@@ -214,7 +214,23 @@ void ic0_stable_read(uintptr_t dst, uint32_t off, uint32_t size) {
   std::cout << "...doing nothing..." << std::endl;
 }
 
+// Mock-IC-only state: last armed global-timer deadline, an invocation
+// counter so tests can prove arm_next() actually issued an ic0 syscall, and
+// a time override (flag + value pair, so clearing flips the flag without
+// silently pinning time at 0). All exposed via the accessor / control
+// helpers further below; native test drivers use them to drive scenarios
+// that wall-clock alone would undermine.
+namespace {
+uint64_t g_mock_armed_global_timer{0};
+uint64_t g_mock_global_timer_set_call_count{0};
+bool g_mock_time_overridden{false};
+uint64_t g_mock_time_override_ns{0};
+} // namespace
+
 uint64_t ic0_time() {
+  if (g_mock_time_overridden) {
+    return g_mock_time_override_ns;
+  }
   uint64_t time_in_ns =
       std::chrono::duration_cast<std::chrono::nanoseconds>(
           std::chrono::high_resolution_clock::now().time_since_epoch())
@@ -222,22 +238,31 @@ uint64_t ic0_time() {
   return time_in_ns;
 }
 
-// Mock IC does not actually fire timers. Native tests drive
-// canister_global_timer manually via MockIC::run_test. We just record the
-// last armed deadline so tests can introspect / log it, and return the
-// previous value as the IC interface spec requires.
-namespace {
-uint64_t g_mock_armed_global_timer{0};
-} // namespace
-
 uint64_t ic0_global_timer_set(uint64_t timestamp_ns) {
   uint64_t previous = g_mock_armed_global_timer;
   g_mock_armed_global_timer = timestamp_ns;
+  ++g_mock_global_timer_set_call_count;
 #if ICPP_VERBOSE > 0
   std::cout << "ic0mock ic0::global_timer_set -> " << timestamp_ns << " (was "
             << previous << ")" << std::endl;
 #endif
   return previous;
+}
+
+uint64_t ic0mock_global_timer_set_call_count() {
+  return g_mock_global_timer_set_call_count;
+}
+
+void ic0mock_set_time_override(uint64_t time_ns) {
+  g_mock_time_overridden = true;
+  g_mock_time_override_ns = time_ns;
+}
+
+void ic0mock_clear_time_override() {
+  // Flip the flag only; do not zero the override value. If a subsequent test
+  // forgot to call set_override and we had reset the value to 0, ic0_time()
+  // would silently pin to 0 instead of returning wall-clock.
+  g_mock_time_overridden = false;
 }
 
 uint32_t ic0_is_controller(uintptr_t src, uint32_t size) {

--- a/src/icpp/ic/ic0mock/ic0.cpp
+++ b/src/icpp/ic/ic0mock/ic0.cpp
@@ -231,10 +231,14 @@ uint64_t ic0_time() {
   if (g_mock_time_overridden) {
     return g_mock_time_override_ns;
   }
-  uint64_t time_in_ns =
-      std::chrono::duration_cast<std::chrono::nanoseconds>(
-          std::chrono::high_resolution_clock::now().time_since_epoch())
-          .count();
+  // steady_clock, not high_resolution_clock: the latter's is_steady is
+  // implementation-defined and on some libc++ targets aliases system_clock,
+  // which can move backward when the wall clock is adjusted. Native timer
+  // tests assume monotonicity (deadline math relies on it), so use the
+  // clock that is_steady is guaranteed to be true for.
+  uint64_t time_in_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            std::chrono::steady_clock::now().time_since_epoch())
+                            .count();
   return time_in_ns;
 }
 

--- a/src/icpp/ic/ic0mock/ic0.h
+++ b/src/icpp/ic/ic0mock/ic0.h
@@ -68,6 +68,8 @@ void ic0_stable_read(uintptr_t dst, uint32_t off, uint32_t size);
 
 uint64_t ic0_time();
 
+uint64_t ic0_global_timer_set(uint64_t timestamp_ns);
+
 uint32_t ic0_is_controller(uintptr_t src, uint32_t size);
 
 void ic0_debug_print(uintptr_t src, uint32_t size);

--- a/src/icpp/ic/ic0mock/ic0.h
+++ b/src/icpp/ic/ic0mock/ic0.h
@@ -76,6 +76,32 @@ void ic0_debug_print(uintptr_t src, uint32_t size);
 
 [[noreturn]] void ic0_trap(uintptr_t src, uint32_t size);
 
+// ----------------------------------------------------------------------------
+// Mock-only test helpers — NOT part of the IC0 API.
+// Native test drivers use these to introspect / control the mock IC.
+
+// Number of times ic0_global_timer_set has been invoked since process start.
+// Tests should snapshot before / after a scenario and assert the delta, not
+// absolute values, since the counter is a single static across all scenarios
+// in the same runner process.
+uint64_t ic0mock_global_timer_set_call_count();
+
+// Pin the value returned by ic0_time() to a fixed nanosecond timestamp.
+// This is needed for tests that must force multiple set_timer calls to land
+// on identical deadlines (the wall-clock would otherwise advance between
+// calls). Implemented with a flag plus value: ic0_time() honors the override
+// only while the flag is set.
+void ic0mock_set_time_override(uint64_t time_ns);
+
+// Clear the time override, restoring genuine wall-clock behavior. This
+// flips a flag — it does NOT set the override value to 0 (which would
+// silently pin time at 0 for any subsequent test that did not explicitly
+// override). Tests that pin time MUST call this on every exit path; with
+// MockIC's exit_on_fail=true semantics, RAII guards do not fire on
+// assertion failure, so prefer either a runner-wide MockIC with
+// exit_on_fail=false, or explicit pre-assertion clears.
+void ic0mock_clear_time_override();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/icpp/ic/ic0mock/mock_ic_constants.h
+++ b/src/icpp/ic/ic0mock/mock_ic_constants.h
@@ -5,6 +5,6 @@
 #include <string>
 
 constexpr std::string_view MOCKIC_CANISTER_SELF = "5ugrv-zqaaa-aaaag-acfna-cai";
-constexpr __uint128_t MOCKIC_INITIAL_CYCLES_BALANCE = 3000000000000;
+constexpr __uint128_t MOCKIC_INITIAL_CYCLES_BALANCE = 3'000'000'000'000ULL;
 constexpr std::string_view MOCKIC_CONTROLLER =
     "expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae";

--- a/src/icpp/ic/icapi/ic_api.cpp
+++ b/src/icpp/ic/icapi/ic_api.cpp
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "ic0.h"
+#include "ic_timers.h"
 
 // ----------------------------------------------------------
 
@@ -31,17 +32,25 @@ IC_API::IC_API(const CanisterBase &canister_entry, const bool &dbug)
     : m_canister_entry(canister_entry), m_debug_print(dbug) {
   // Always start with a clean type table registry in the registry singleton
   CandidSerializeTypeTableRegistry::get_instance().clear();
-  // Fill 'm_B_in' with the bytes of msg_arg_data
-  std::vector<uint8_t> bytes(ic0_msg_arg_data_size());
-  ic0_msg_arg_data_copy(reinterpret_cast<uintptr_t>(bytes.data()), 0,
-                        bytes.size());
-  m_B_in.store(bytes.data(), bytes.size());
 
-  // Get the principal of caller
-  std::vector<uint8_t> bytes_caller(ic0_msg_caller_size());
-  ic0_msg_caller_copy(reinterpret_cast<uintptr_t>(bytes_caller.data()), 0,
-                      bytes_caller.size());
-  m_caller = CandidTypePrincipal(bytes_caller);
+  // ic0.msg_arg_data_* and ic0.msg_caller_* are not available in T (timer /
+  // heartbeat) entries — the IC traps if we call them. Skip both sections
+  // for those entries; m_B_in stays empty and m_caller stays default.
+  const bool has_msg_context = !m_canister_entry.is_entry_T();
+
+  if (has_msg_context) {
+    // Fill 'm_B_in' with the bytes of msg_arg_data
+    std::vector<uint8_t> bytes(ic0_msg_arg_data_size());
+    ic0_msg_arg_data_copy(reinterpret_cast<uintptr_t>(bytes.data()), 0,
+                          bytes.size());
+    m_B_in.store(bytes.data(), bytes.size());
+
+    // Get the principal of caller
+    std::vector<uint8_t> bytes_caller(ic0_msg_caller_size());
+    ic0_msg_caller_copy(reinterpret_cast<uintptr_t>(bytes_caller.data()), 0,
+                        bytes_caller.size());
+    m_caller = CandidTypePrincipal(bytes_caller);
+  }
 
   // Get  canister id
   std::vector<uint8_t> bytes_canister_self(ic0_canister_self_size());
@@ -52,11 +61,15 @@ IC_API::IC_API(const CanisterBase &canister_entry, const bool &dbug)
 
   if (m_debug_print) {
     debug_print("\n--");
-    debug_print("IC_API caller's principal       :" + m_caller.get_text());
+    if (has_msg_context) {
+      debug_print("IC_API caller's principal       :" + m_caller.get_text());
+    }
     debug_print("IC_API canister_self's principal:" +
                 m_canister_self.get_text());
-    debug_print("IC_API received these bytes over the wire:");
-    m_B_in.debug_print();
+    if (has_msg_context) {
+      debug_print("IC_API received these bytes over the wire:");
+      m_B_in.debug_print();
+    }
   }
 }
 
@@ -107,6 +120,23 @@ void IC_API::trap(const char *message) {
 void IC_API::trap(const std::string &s) { IC_API::trap(s.c_str()); }
 
 uint64_t IC_API::time() { return ic0_time(); }
+
+uint64_t IC_API::set_timer(uint64_t delay_ns, std::function<void()> cb) {
+  return IcTimers::instance().add_one_shot(delay_ns, std::move(cb));
+}
+
+uint64_t IC_API::set_timer_recurring(uint64_t period_ns,
+                                     std::function<void()> cb) {
+  return IcTimers::instance().add_recurring(period_ns, std::move(cb));
+}
+
+bool IC_API::cancel_timer(uint64_t id) {
+  return IcTimers::instance().cancel(id);
+}
+
+uint64_t IC_API::global_timer_set_raw(uint64_t timestamp_ns) {
+  return ic0_global_timer_set(timestamp_ns);
+}
 
 // DeSerialize the byte stream received over the wire
 void IC_API::from_wire(CandidArgs A) {

--- a/src/icpp/ic/icapi/ic_api.cpp
+++ b/src/icpp/ic/icapi/ic_api.cpp
@@ -134,6 +134,8 @@ bool IC_API::cancel_timer(uint64_t id) {
   return IcTimers::instance().cancel(id);
 }
 
+void IC_API::cancel_all_timers() { IcTimers::instance().clear(); }
+
 // DeSerialize the byte stream received over the wire
 void IC_API::from_wire(CandidArgs A) {
   if (m_called_from_wire) {

--- a/src/icpp/ic/icapi/ic_api.cpp
+++ b/src/icpp/ic/icapi/ic_api.cpp
@@ -134,10 +134,6 @@ bool IC_API::cancel_timer(uint64_t id) {
   return IcTimers::instance().cancel(id);
 }
 
-uint64_t IC_API::global_timer_set_raw(uint64_t timestamp_ns) {
-  return ic0_global_timer_set(timestamp_ns);
-}
-
 // DeSerialize the byte stream received over the wire
 void IC_API::from_wire(CandidArgs A) {
   if (m_called_from_wire) {

--- a/src/icpp/ic/icapi/ic_api.h
+++ b/src/icpp/ic/icapi/ic_api.h
@@ -58,6 +58,34 @@ public:
                                       std::function<void()> cb);
   static bool cancel_timer(uint64_t id); // docs end: set_timer
 
+  // docs start: cancel_all_timers
+  // Cancels every currently registered timer (one-shot and recurring) and
+  // disarms the IC's global timer.
+  //
+  // Valid entry points: canister_init, canister_post_upgrade,
+  // canister_pre_upgrade, canister_update, canister_heartbeat,
+  // canister_global_timer, and reply / reject / cleanup callbacks. Not
+  // valid from canister_query — ic0.global_timer_set is not available in
+  // query context per the IC interface spec, and query mutations would be
+  // discarded anyway.
+  //
+  // Current-dispatch semantics: if called from inside a timer callback,
+  // callbacks already collected into the in-flight dispatch_due() batch
+  // will still execute — they were copied to a local vector before any
+  // callback ran. What is cancelled is *future* firings: any recurring
+  // timer's just-rescheduled next deadline, plus any one-shot timers not
+  // yet drained from the multimap. The IC's global timer is disarmed and
+  // stays disarmed until something else calls a set_timer* API.
+  //
+  // Raw-call interaction: users can still call ic0_global_timer_set
+  // directly via #include "ic0.h". cancel_all_timers() only clears the
+  // IcTimers registry and disarms the IC at the moment it runs — a
+  // subsequent direct ic0_global_timer_set(t) call from user code can
+  // re-arm the IC outside the registry's knowledge. Mixing the two is
+  // the user's responsibility; the registry's correctness boundary does
+  // not extend across that fence.
+  static void cancel_all_timers(); // docs end: cancel_all_timers
+
   // Note: rev0 also exposed `IC_API::global_timer_set_raw(timestamp_ns)`
   // as a thin pass-through to ic0.global_timer_set. It was removed in
   // rev1 because mixing it with the IcTimers registry desynchronized the

--- a/src/icpp/ic/icapi/ic_api.h
+++ b/src/icpp/ic/icapi/ic_api.h
@@ -70,12 +70,15 @@ public:
   // discarded anyway.
   //
   // Current-dispatch semantics: if called from inside a timer callback,
-  // callbacks already collected into the in-flight dispatch_due() batch
-  // will still execute — they were copied to a local vector before any
-  // callback ran. What is cancelled is *future* firings: any recurring
-  // timer's just-rescheduled next deadline, plus any one-shot timers not
-  // yet drained from the multimap. The IC's global timer is disarmed and
-  // stays disarmed until something else calls a set_timer* API.
+  // any due timer in the same dispatch batch that has NOT yet executed
+  // is also cancelled — dispatch_due() looks each id up in the registry
+  // at execute time and skips entries that have been removed. (Recurring
+  // timers had their next deadline rescheduled during the batch's gather
+  // phase; cancel_all_timers() removes them too, so they don't fire then
+  // or later.) The currently-executing callback is not interrupted and
+  // any callbacks that have already returned in this batch keep their
+  // observable effects. The IC's global timer is disarmed and stays
+  // disarmed until something else calls a set_timer* API.
   //
   // Raw-call interaction: users can still call ic0_global_timer_set
   // directly via #include "ic0.h". cancel_all_timers() only clears the

--- a/src/icpp/ic/icapi/ic_api.h
+++ b/src/icpp/ic/icapi/ic_api.h
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <deque>
+#include <functional>
 #include <list>
 #include <map>
 #include <set>
@@ -48,6 +49,19 @@ public:
 
   // docs start: demo_time
   static uint64_t time(); // docs end: demo_time
+
+  // Multi-timer scheduler layered on ic0.global_timer_set. Returns a
+  // non-zero id usable with cancel_timer.
+  // docs start: set_timer
+  static uint64_t set_timer(uint64_t delay_ns, std::function<void()> cb);
+  static uint64_t set_timer_recurring(uint64_t period_ns,
+                                      std::function<void()> cb);
+  static bool cancel_timer(uint64_t id); // docs end: set_timer
+
+  // Thin pass-through to ic0.global_timer_set for callers that want to
+  // bypass the IcTimers registry and manage scheduling themselves.
+  // Returns the previous deadline. timestamp_ns == 0 disarms.
+  static uint64_t global_timer_set_raw(uint64_t timestamp_ns);
 
   // docs start: get_caller
   CandidTypePrincipal get_caller(); // docs end: get_caller

--- a/src/icpp/ic/icapi/ic_api.h
+++ b/src/icpp/ic/icapi/ic_api.h
@@ -58,10 +58,13 @@ public:
                                       std::function<void()> cb);
   static bool cancel_timer(uint64_t id); // docs end: set_timer
 
-  // Thin pass-through to ic0.global_timer_set for callers that want to
-  // bypass the IcTimers registry and manage scheduling themselves.
-  // Returns the previous deadline. timestamp_ns == 0 disarms.
-  static uint64_t global_timer_set_raw(uint64_t timestamp_ns);
+  // Note: rev0 also exposed `IC_API::global_timer_set_raw(timestamp_ns)`
+  // as a thin pass-through to ic0.global_timer_set. It was removed in
+  // rev1 because mixing it with the IcTimers registry desynchronized the
+  // armed-deadline cache (the wrapper bypassed IcTimers but was named as
+  // if it composed with it). Callers that genuinely want raw access can
+  // `#include "ic0.h"` and call `ic0_global_timer_set` directly — the
+  // conflict with IcTimers is then explicit at the call site.
 
   // docs start: get_caller
   CandidTypePrincipal get_caller(); // docs end: get_caller

--- a/src/icpp/ic/icapi/ic_timers.cpp
+++ b/src/icpp/ic/icapi/ic_timers.cpp
@@ -55,6 +55,14 @@ void IcTimers::arm_next() {
 }
 
 void IcTimers::dispatch_due(uint64_t now_ns) {
+  // The IC fired our one-shot global timer to invoke this entry, so whatever
+  // we had armed is consumed at the IC level. Invalidate the cache so
+  // arm_next() will re-arm unconditionally — otherwise, when the remaining
+  // earliest deadline equals the previously-armed value (e.g. >MAX_PER_TICK
+  // timers all sharing a deadline), arm_next would skip the syscall and the
+  // remaining timers would be permanently stranded.
+  m_armed_deadline = 0;
+
   std::vector<std::function<void()>> to_run;
   to_run.reserve(MAX_PER_TICK);
 

--- a/src/icpp/ic/icapi/ic_timers.cpp
+++ b/src/icpp/ic/icapi/ic_timers.cpp
@@ -1,9 +1,23 @@
 #include "ic_timers.h"
 
+#include <cstdint>
+#include <limits>
 #include <utility>
 #include <vector>
 
 #include "ic0.h"
+
+namespace {
+// Saturating uint64_t addition. Used everywhere we add a delay/period to a
+// nanosecond timestamp so a near-UINT64_MAX argument can't wrap the deadline
+// into the past and fire immediately. Saturating to UINT64_MAX is acceptable
+// because the IC's global timer accepts any uint64_t and "the very far
+// future" is the right behavior for absurd delays.
+inline uint64_t saturating_add_u64(uint64_t a, uint64_t b) {
+  uint64_t max = std::numeric_limits<uint64_t>::max();
+  return (b > max - a) ? max : a + b;
+}
+} // namespace
 
 IcTimers &IcTimers::instance() {
   static IcTimers s;
@@ -26,12 +40,12 @@ uint64_t IcTimers::insert(uint64_t deadline_ns, uint64_t period_ns,
 }
 
 uint64_t IcTimers::add_one_shot(uint64_t delay_ns, std::function<void()> cb) {
-  uint64_t deadline = ic0_time() + delay_ns;
+  uint64_t deadline = saturating_add_u64(ic0_time(), delay_ns);
   return insert(deadline, 0, std::move(cb));
 }
 
 uint64_t IcTimers::add_recurring(uint64_t period_ns, std::function<void()> cb) {
-  uint64_t deadline = ic0_time() + period_ns;
+  uint64_t deadline = saturating_add_u64(ic0_time(), period_ns);
   return insert(deadline, period_ns, std::move(cb));
 }
 
@@ -73,7 +87,15 @@ void IcTimers::dispatch_due(uint64_t now_ns) {
   // remaining timers would be permanently stranded.
   m_armed_deadline = 0;
 
-  std::vector<std::function<void()>> to_run;
+  // Gather phase: collect IDs of due timers (up to MAX_PER_TICK), then
+  // mutate the registry. We deliberately store *ids*, not callback copies,
+  // so a callback that calls cancel(other_id) or cancel_all_timers() during
+  // the execute phase below actually prevents the targeted timer from
+  // firing — the lookup in execute consults the live m_by_id and skips
+  // entries that have been removed mid-batch. The earlier copy-cb-and-run
+  // design fired cancelled timers anyway because the cb had already been
+  // copied; that was observably wrong cancel semantics.
+  std::vector<uint64_t> to_run;
   to_run.reserve(MAX_PER_TICK);
 
   while (to_run.size() < MAX_PER_TICK) {
@@ -88,31 +110,58 @@ void IcTimers::dispatch_due(uint64_t now_ns) {
       continue;
     }
 
-    to_run.push_back(sit->second.entry.cb);
+    to_run.push_back(id);
 
     if (sit->second.entry.period_ns > 0) {
       uint64_t pivot = sit->second.entry.deadline_ns;
       uint64_t period = sit->second.entry.period_ns;
       // Motoko catch-up: skip missed periods so we don't fire-storm after
-      // a slow tick. Always lands strictly past now_ns.
-      uint64_t next = (now_ns >= pivot)
-                          ? pivot + period * (1 + (now_ns - pivot) / period)
-                          : pivot + period;
+      // a slow tick. Always lands strictly past now_ns. Saturating add
+      // because the user's chosen period plus pivot can overflow on
+      // adversarial inputs; we'd rather "never fires again" than wrap to
+      // the past and fire immediately in a tight loop.
+      uint64_t skipped = (now_ns >= pivot) ? (now_ns - pivot) / period : 0;
+      uint64_t advance = saturating_add_u64(skipped, 1);
+      // next = pivot + period * advance, computed carefully:
+      uint64_t increment =
+          (period > std::numeric_limits<uint64_t>::max() / advance)
+              ? std::numeric_limits<uint64_t>::max()
+              : period * advance;
+      uint64_t next = saturating_add_u64(pivot, increment);
       m_by_deadline.erase(it);
       sit->second.entry.deadline_ns = next;
       sit->second.it = m_by_deadline.insert({next, id});
     } else {
+      // One-shot: remove from the deadline index now (so the next gather
+      // iteration sees the next entry), but keep it in m_by_id so that
+      //   (a) the execute phase can still find the cb at run time, and
+      //   (b) cancel(id) called from another callback in this batch can
+      //       remove it and prevent it from firing.
       m_by_deadline.erase(it);
-      m_by_id.erase(sit);
     }
   }
 
-  // Run callbacks before re-arming, so any timers they register or cancel
-  // are reflected in the value we hand to ic0.global_timer_set.
+  // Execute phase: look up each id at run time. If a previous callback
+  // cancelled this id (or cleared the whole registry via cancel_all_timers),
+  // m_by_id.find(id) returns end and we skip — that's the cancel-mid-batch
+  // semantics the gather phase preserves above.
+  //
+  // For one-shots we also erase the entry from m_by_id BEFORE invoking the
+  // cb, so a cb that calls cancel(its-own-id) or set_timer() observes a
+  // consistent registry state ("I'm no longer registered, anything I add
+  // now is fresh").
+  //
   // Note: WASM is built with -fno-exceptions; if a callback traps the
   // entire message rolls back, including the registry mutations above.
-  for (auto &cb : to_run)
+  for (uint64_t id : to_run) {
+    auto sit = m_by_id.find(id);
+    if (sit == m_by_id.end()) continue;
+    auto cb = sit->second.entry.cb; // copy, in case cb mutates m_by_id
+    if (sit->second.entry.period_ns == 0) {
+      m_by_id.erase(sit);
+    }
     cb();
+  }
 
   arm_next();
 }

--- a/src/icpp/ic/icapi/ic_timers.cpp
+++ b/src/icpp/ic/icapi/ic_timers.cpp
@@ -1,0 +1,100 @@
+#include "ic_timers.h"
+
+#include <utility>
+#include <vector>
+
+#include "ic0.h"
+
+IcTimers &IcTimers::instance() {
+  static IcTimers s;
+  return s;
+}
+
+uint64_t IcTimers::insert(uint64_t deadline_ns, uint64_t period_ns,
+                          std::function<void()> cb) {
+  uint64_t id = m_next_id++;
+  auto it = m_by_deadline.insert({deadline_ns, id});
+  Stored s;
+  s.entry.id = id;
+  s.entry.deadline_ns = deadline_ns;
+  s.entry.period_ns = period_ns;
+  s.entry.cb = std::move(cb);
+  s.it = it;
+  m_by_id.emplace(id, std::move(s));
+  arm_next();
+  return id;
+}
+
+uint64_t IcTimers::add_one_shot(uint64_t delay_ns, std::function<void()> cb) {
+  uint64_t deadline = ic0_time() + delay_ns;
+  return insert(deadline, 0, std::move(cb));
+}
+
+uint64_t IcTimers::add_recurring(uint64_t period_ns, std::function<void()> cb) {
+  uint64_t deadline = ic0_time() + period_ns;
+  return insert(deadline, period_ns, std::move(cb));
+}
+
+bool IcTimers::cancel(uint64_t id) {
+  auto sit = m_by_id.find(id);
+  if (sit == m_by_id.end()) return false;
+  m_by_deadline.erase(sit->second.it);
+  m_by_id.erase(sit);
+  arm_next();
+  return true;
+}
+
+std::size_t IcTimers::size() const { return m_by_id.size(); }
+
+void IcTimers::arm_next() {
+  uint64_t target = m_by_deadline.empty() ? 0 : m_by_deadline.begin()->first;
+  if (target != m_armed_deadline) {
+    ic0_global_timer_set(target);
+    m_armed_deadline = target;
+  }
+}
+
+void IcTimers::dispatch_due(uint64_t now_ns) {
+  std::vector<std::function<void()>> to_run;
+  to_run.reserve(MAX_PER_TICK);
+
+  while (to_run.size() < MAX_PER_TICK) {
+    auto it = m_by_deadline.begin();
+    if (it == m_by_deadline.end() || it->first > now_ns) break;
+
+    uint64_t id = it->second;
+    auto sit = m_by_id.find(id);
+    if (sit == m_by_id.end()) {
+      // Defensive: deadline index out of sync — drop the orphan and continue.
+      m_by_deadline.erase(it);
+      continue;
+    }
+
+    to_run.push_back(sit->second.entry.cb);
+
+    if (sit->second.entry.period_ns > 0) {
+      uint64_t pivot = sit->second.entry.deadline_ns;
+      uint64_t period = sit->second.entry.period_ns;
+      // Motoko catch-up: skip missed periods so we don't fire-storm after
+      // a slow tick. Always lands strictly past now_ns.
+      uint64_t next = (now_ns >= pivot)
+                          ? pivot + period * (1 + (now_ns - pivot) / period)
+                          : pivot + period;
+      m_by_deadline.erase(it);
+      sit->second.entry.deadline_ns = next;
+      sit->second.it = m_by_deadline.insert({next, id});
+    } else {
+      m_by_deadline.erase(it);
+      m_by_id.erase(sit);
+    }
+  }
+
+  // Run callbacks before re-arming, so any timers they register or cancel
+  // are reflected in the value we hand to ic0.global_timer_set.
+  // Note: WASM is built with -fno-exceptions; if a callback traps the
+  // entire message rolls back, including the registry mutations above.
+  for (auto &cb : to_run)
+    cb();
+
+  arm_next();
+}

--- a/src/icpp/ic/icapi/ic_timers.cpp
+++ b/src/icpp/ic/icapi/ic_timers.cpp
@@ -46,6 +46,16 @@ bool IcTimers::cancel(uint64_t id) {
 
 std::size_t IcTimers::size() const { return m_by_id.size(); }
 
+void IcTimers::clear() {
+  m_by_deadline.clear();
+  m_by_id.clear();
+  m_armed_deadline = 0;
+  // Unconditionally disarm — do NOT defer to arm_next()'s cache-equality
+  // skip here. After raw / custom interactions or dispatch edges the cache
+  // may not reflect IC state; correctness beats saving one syscall.
+  ic0_global_timer_set(0);
+}
+
 void IcTimers::arm_next() {
   uint64_t target = m_by_deadline.empty() ? 0 : m_by_deadline.begin()->first;
   if (target != m_armed_deadline) {

--- a/src/icpp/ic/icapi/ic_timers.h
+++ b/src/icpp/ic/icapi/ic_timers.h
@@ -44,9 +44,10 @@ public:
   // Correctness beats saving one syscall.
   //
   // Current-dispatch semantics: if called from inside a timer callback,
-  // callbacks already collected into the in-flight dispatch_due() batch
-  // still execute (they were copied to a local vector before any callback
-  // ran). What is cancelled is *future* firings.
+  // due timers in the same batch that have NOT yet executed are also
+  // cancelled — dispatch_due() looks each id up in m_by_id at execute
+  // time, and clear() empties m_by_id, so post-clear lookups skip those
+  // entries. The currently-executing callback continues to completion.
   void clear();
 
   // Fire all timers whose deadline is <= now_ns, capped at MAX_PER_TICK.

--- a/src/icpp/ic/icapi/ic_timers.h
+++ b/src/icpp/ic/icapi/ic_timers.h
@@ -36,6 +36,19 @@ public:
   // Remove a registered timer. Returns true if the id was found.
   bool cancel(uint64_t id);
 
+  // Cancel every registered timer (one-shot and recurring) and unconditionally
+  // disarm the IC's global timer. The unconditional disarm — i.e., always
+  // calling ic0_global_timer_set(0) regardless of m_armed_deadline — is
+  // deliberate: clear() is a reset helper, and prior raw / custom
+  // interactions or dispatch edges may have desynchronized the cache.
+  // Correctness beats saving one syscall.
+  //
+  // Current-dispatch semantics: if called from inside a timer callback,
+  // callbacks already collected into the in-flight dispatch_due() batch
+  // still execute (they were copied to a local vector before any callback
+  // ran). What is cancelled is *future* firings.
+  void clear();
+
   // Fire all timers whose deadline is <= now_ns, capped at MAX_PER_TICK.
   // Recurring timers are rescheduled with Motoko-style catch-up.
   // Called from canister_global_timer.

--- a/src/icpp/ic/icapi/ic_timers.h
+++ b/src/icpp/ic/icapi/ic_timers.h
@@ -1,0 +1,78 @@
+// Multi-timer registry layered on top of the IC's single global timer.
+//
+// The IC platform exposes one timer per canister via
+// ic0.global_timer_set / canister_global_timer. IcTimers extends that into
+// a scheduler that supports multiple one-shot and recurring timers, each
+// identified by an id that can be passed to cancel().
+//
+// Inspired by Motoko's prelude/internals.mo. Implemented with std::multimap
+// instead of a hand-rolled BST.
+//
+// Single-threaded: the IC runs one message at a time, so no synchronization
+// is needed. Timer state is in-memory only and is not preserved across
+// canister upgrades (re-register timers in canister_post_upgrade if needed).
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <unordered_map>
+
+class IcTimers {
+public:
+  static IcTimers &instance();
+
+  // Schedule a callback to fire once after delay_ns nanoseconds. Returns a
+  // non-zero id that can be passed to cancel().
+  uint64_t add_one_shot(uint64_t delay_ns, std::function<void()> cb);
+
+  // Schedule a callback to fire repeatedly every period_ns nanoseconds. The
+  // first firing is one period after registration. A period of 0 is treated
+  // as a one-shot fire-once-at-now timer to match Motoko semantics.
+  uint64_t add_recurring(uint64_t period_ns, std::function<void()> cb);
+
+  // Remove a registered timer. Returns true if the id was found.
+  bool cancel(uint64_t id);
+
+  // Fire all timers whose deadline is <= now_ns, capped at MAX_PER_TICK.
+  // Recurring timers are rescheduled with Motoko-style catch-up.
+  // Called from canister_global_timer.
+  void dispatch_due(uint64_t now_ns);
+
+  // Number of registered timers (for tests / introspection).
+  std::size_t size() const;
+
+private:
+  IcTimers() = default;
+  IcTimers(const IcTimers &) = delete;
+  IcTimers &operator=(const IcTimers &) = delete;
+
+  // Match Motoko's per-tick cap to prevent timer storms from starving other
+  // work in the same message budget.
+  static constexpr std::size_t MAX_PER_TICK = 10;
+
+  struct Entry {
+    uint64_t id{0};
+    uint64_t deadline_ns{0};
+    uint64_t period_ns{0}; // 0 = one-shot
+    std::function<void()> cb;
+  };
+
+  using DeadlineIndex = std::multimap<uint64_t, uint64_t>;
+
+  struct Stored {
+    Entry entry;
+    DeadlineIndex::iterator it;
+  };
+
+  uint64_t insert(uint64_t deadline_ns, uint64_t period_ns,
+                  std::function<void()> cb);
+  void arm_next();
+
+  DeadlineIndex m_by_deadline;
+  std::unordered_map<uint64_t, Stored> m_by_id;
+  uint64_t m_next_id{1};
+  uint64_t m_armed_deadline{0};
+};

--- a/src/icpp/options_build.py
+++ b/src/icpp/options_build.py
@@ -4,9 +4,11 @@ from typing import Optional
 import typer
 
 option_to_compile_values = ["all", "mine", "mine-no-lib"]
+# pylint: disable=invalid-name
 option_to_compile_values_string = f"[{'/'.join(option_to_compile_values)}]"
 
 option_generate_bindings_values = ["yes", "no"]
+# pylint: disable=invalid-name
 option_generate_bindings_values_string = (
     f"[{'/'.join(option_generate_bindings_values)}]"
 )

--- a/src/icpp/smoketest.py
+++ b/src/icpp/smoketest.py
@@ -1,5 +1,6 @@
 """Functions to be used in a pytest test"""
 
+import re
 import subprocess
 import json
 from pathlib import Path
@@ -9,6 +10,21 @@ import pytest  # pylint: disable=unused-import
 from icpp.run_shell_cmd import run_shell_cmd
 
 DFX = "dfx"
+
+# dfx 0.32.0 started emitting this deprecation banner on stderr for every
+# invocation. run_shell_cmd merges stderr into stdout, so the banner ends up
+# in our captured response and corrupts string-equality assertions in
+# pytest. Strip exactly this known line — narrow enough that it cannot
+# accidentally swallow legitimate canister output. Update or extend if dfx
+# adds new pre-call warnings later.
+_DFX_DEPRECATION_RE = re.compile(
+    r"^WARNING: dfx is deprecated.*$\n?", flags=re.MULTILINE
+)
+
+
+def _strip_dfx_warnings(s: str) -> str:
+    """Remove the known dfx deprecation banner from captured shell output."""
+    return _DFX_DEPRECATION_RE.sub("", s)
 
 
 def call_canister_api(
@@ -59,7 +75,7 @@ def call_canister_api(
             cwd=Path(dfx_json_path).parent,
             timeout_seconds=timeout_seconds,
         )
-        response = response.rstrip("\n")
+        response = _strip_dfx_warnings(response).rstrip("\n")
     except subprocess.CalledProcessError as e:
         if "Error: Failed to determine id for canister" in e.output:
             msg = (
@@ -183,7 +199,7 @@ def get_canister_id(
             cwd=Path(dfx_json_path).parent,
             timeout_seconds=timeout_seconds,
         )
-        canister_id = response.rstrip("\n")
+        canister_id = _strip_dfx_warnings(response).rstrip("\n")
     except subprocess.CalledProcessError as e:
         if "Error: Failed to determine id for canister" in e.output:
             msg = (
@@ -213,7 +229,7 @@ def get_local_webserver_port(
         response = run_shell_cmd(
             arg, capture_output=True, timeout_seconds=timeout_seconds
         )
-        webserver_port = response.rstrip("\n")
+        webserver_port = _strip_dfx_warnings(response).rstrip("\n")
     except subprocess.CalledProcessError as e:
         response = f"Failed to get local network's webserver port:" f"{e.output}"
 
@@ -259,7 +275,7 @@ def get_identity() -> str:
     arg = f"{DFX} identity whoami "
     try:
         identity = run_shell_cmd(arg, capture_output=True, timeout_seconds=30)
-        identity = identity.rstrip("\n")
+        identity = _strip_dfx_warnings(identity).rstrip("\n")
     except subprocess.CalledProcessError as e:
         pytest.fail(f"ERROR: command {arg} failed with error:\n{e.output}")
 
@@ -280,7 +296,7 @@ def get_principal() -> str:
     arg = f"{DFX} identity get-principal "
     try:
         principal = run_shell_cmd(arg, capture_output=True, timeout_seconds=30)
-        principal = principal.rstrip("\n")
+        principal = _strip_dfx_warnings(principal).rstrip("\n")
     except subprocess.CalledProcessError as e:
         pytest.fail(f"ERROR: command {arg} failed with error:\n{e.output}")
 

--- a/src/icpp/smoketest.py
+++ b/src/icpp/smoketest.py
@@ -212,8 +212,11 @@ def get_canister_id(
                 "*******************************************"
             )
             pytest.exit(msg)
-        else:
-            response = f"Failed to get id of canister '{canister_name}':" f"{e.output}"
+        # pytest.fail raises, so canister_id never has to be defined for this
+        # path. The earlier code built `response` here and fell through to
+        # `return canister_id`, which raised UnboundLocalError and hid the
+        # real dfx error.
+        pytest.fail(f"Failed to get id of canister '{canister_name}': {e.output}")
 
     return canister_id
 
@@ -231,7 +234,11 @@ def get_local_webserver_port(
         )
         webserver_port = _strip_dfx_warnings(response).rstrip("\n")
     except subprocess.CalledProcessError as e:
-        response = f"Failed to get local network's webserver port:" f"{e.output}"
+        # pytest.fail raises so webserver_port never has to be defined for
+        # this path. The earlier code built a `response` string here and
+        # fell through to `return webserver_port`, which raised
+        # UnboundLocalError and hid the real dfx error.
+        pytest.fail(f"Failed to get local network's webserver port: {e.output}")
 
     return webserver_port
 

--- a/src/icpp/utils.py
+++ b/src/icpp/utils.py
@@ -29,7 +29,7 @@ def rmtree_force(path: Union[str, Path]) -> None:
     of `onexc` (with a different 3rd-arg signature). pylint 3.x running
     against Python 3.13's stdlib stubs flags `onerror=` calls as
     `W4903 deprecated-argument`. To keep CI clean across the
-    Python 3.10–3.14 matrix we branch by version here. `remove_readonly`
+    Python 3.10-3.14 matrix we branch by version here. `remove_readonly`
     above ignores the 3rd argument so the same callback works for both.
     """
     # On each Python version one branch below is "right" and the other is

--- a/src/icpp/utils.py
+++ b/src/icpp/utils.py
@@ -1,21 +1,47 @@
 """Utility functions """
 
 import os
+import shutil
 import stat
-from typing import Any, Callable
+import sys
+from pathlib import Path
+from typing import Any, Callable, Union
 
 
 def remove_readonly(func: Callable[..., Any], path: str, _exc_info: Any) -> None:
-    """shutil.rmtree onerror callback: clear the readonly bit and retry.
+    """shutil.rmtree onerror / onexc callback: clear the readonly bit and retry.
 
-    Signature matches typeshed's expected onerror callable type, which in
-    mypy 1.13+ stubs is
-        Callable[[Callable[..., Any], str,
-                  tuple[type[BaseException], BaseException, TracebackType]],
-                 object]
-    The third argument (the sys.exc_info tuple) is unused here; we accept
-    Any to stay compatible across the Python 3.10-3.14 matrix without
-    importing TracebackType conditionally.
+    The third argument is unused here, so the same callable is valid for
+    both signatures:
+      - 3.10/3.11 onerror : (func, path, sys.exc_info() tuple)
+      - 3.12+    onexc   : (func, path, exception_instance)
+    Typed as Any so we don't have to import TracebackType conditionally.
     """
     os.chmod(path, stat.S_IWRITE)  # pylint: disable = no-member
     func(path)
+
+
+def rmtree_force(path: Union[str, Path]) -> None:
+    """Like shutil.rmtree, but clears readonly bits on the way down and
+    silences the Python 3.12 deprecation of `onerror`.
+
+    `shutil.rmtree`'s `onerror` parameter was deprecated in 3.12 in favor
+    of `onexc` (with a different 3rd-arg signature). pylint 3.x running
+    against Python 3.13's stdlib stubs flags `onerror=` calls as
+    `W4903 deprecated-argument`. To keep CI clean across the
+    Python 3.10–3.14 matrix we branch by version here. `remove_readonly`
+    above ignores the 3rd argument so the same callback works for both.
+    """
+    # On each Python version one branch below is "right" and the other is
+    # statically unreachable. Pylint nonetheless analyzes both with the
+    # local stdlib stubs and would flag whichever branch doesn't match —
+    # `unexpected-keyword-arg` for `onexc` on 3.10/3.11, and
+    # `deprecated-argument` for `onerror` on 3.12+. Both inline disables
+    # are needed; the inactive one is silenced by `useless-suppression`
+    # in .pylintrc.
+    if sys.version_info >= (3, 12):
+        # pylint: disable=unexpected-keyword-arg
+        shutil.rmtree(path, onexc=remove_readonly)
+    else:
+        # pylint: disable=deprecated-argument
+        shutil.rmtree(path, onerror=remove_readonly)

--- a/src/icpp/utils.py
+++ b/src/icpp/utils.py
@@ -36,12 +36,15 @@ def rmtree_force(path: Union[str, Path]) -> None:
     # statically unreachable. Pylint nonetheless analyzes both with the
     # local stdlib stubs and would flag whichever branch doesn't match —
     # `unexpected-keyword-arg` for `onexc` on 3.10/3.11, and
-    # `deprecated-argument` for `onerror` on 3.12+. Both inline disables
-    # are needed; the inactive one is silenced by `useless-suppression`
-    # in .pylintrc.
+    # `deprecated-argument` for `onerror` on 3.12+. Both `disable-next`
+    # comments are needed; the inactive one is silenced by
+    # `useless-suppression` in .pylintrc. Note: `disable-next=` is used
+    # rather than a free-standing `disable=` because the latter's
+    # line-scope rules vary across pylint versions and let the warning
+    # leak through in CI on Python 3.12+.
     if sys.version_info >= (3, 12):
-        # pylint: disable=unexpected-keyword-arg
+        # pylint: disable-next=unexpected-keyword-arg
         shutil.rmtree(path, onexc=remove_readonly)
     else:
-        # pylint: disable=deprecated-argument
+        # pylint: disable-next=deprecated-argument
         shutil.rmtree(path, onerror=remove_readonly)

--- a/src/icpp/utils.py
+++ b/src/icpp/utils.py
@@ -2,10 +2,20 @@
 
 import os
 import stat
-from typing import Callable
+from typing import Any, Callable
 
 
-def remove_readonly(func: Callable[[str], None], path: str, _: None) -> None:
-    """Make file writeable, then try again to apply func"""
+def remove_readonly(func: Callable[..., Any], path: str, _exc_info: Any) -> None:
+    """shutil.rmtree onerror callback: clear the readonly bit and retry.
+
+    Signature matches typeshed's expected onerror callable type, which in
+    mypy 1.13+ stubs is
+        Callable[[Callable[..., Any], str,
+                  tuple[type[BaseException], BaseException, TracebackType]],
+                 object]
+    The third argument (the sys.exc_info tuple) is unused here; we accept
+    Any to stay compatible across the Python 3.10-3.14 matrix without
+    importing TracebackType conditionally.
+    """
     os.chmod(path, stat.S_IWRITE)  # pylint: disable = no-member
     func(path)

--- a/test/canisters/canister_hooks/scripts/optimize_wasm.py
+++ b/test/canisters/canister_hooks/scripts/optimize_wasm.py
@@ -1,6 +1,7 @@
 """
 A demo post_wasm_function.
 """
+
 from pathlib import Path
 import shutil
 from icpp import icpp_toml

--- a/test/canisters/canister_timers/dfx.json
+++ b/test/canisters/canister_timers/dfx.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "canisters": {
+    "my_canister": {
+      "type": "custom",
+      "candid": "build/my_canister.did",
+      "wasm": "build/my_canister.wasm"
+    }
+  },
+  "defaults": {
+    "build": {
+      "args": "",
+      "packtool": ""
+    }
+  }
+}

--- a/test/canisters/canister_timers/icpp.toml
+++ b/test/canisters/canister_timers/icpp.toml
@@ -1,0 +1,15 @@
+[build-wasm]
+canister = "my_canister"
+did_path = "src/my_canister.did"
+cpp_paths = ["src/*.cpp"]
+cpp_include_dirs = []
+cpp_compile_flags = []
+cpp_link_flags = []
+c_paths = []
+c_compile_flags = []
+[build-native]
+cpp_paths = ["native/main.cpp"]
+cpp_compile_flags = []
+cpp_link_flags = []
+c_paths = []
+c_compile_flags = []

--- a/test/canisters/canister_timers/native/main.cpp
+++ b/test/canisters/canister_timers/native/main.cpp
@@ -192,9 +192,8 @@ int main() {
   extra_failures += expect_eq_u64(
       "[pinned] ic0_global_timer_set call delta after second dispatch (registry empty -> already disarmed -> skip)",
       cnt_d - cnt_c, 0);
-  extra_failures +=
-      expect_eq_u64("[pinned] g_one_shot_count delta total", g_one_shot_count,
-                    shots_before + 15);
+  extra_failures += expect_eq_u64("[pinned] g_one_shot_count delta total",
+                                  g_one_shot_count, shots_before + 15);
   extra_failures +=
       expect_eq_u64("[pinned] registry empty after second dispatch",
                     IcTimers::instance().size(), 0);
@@ -203,9 +202,9 @@ int main() {
   // armed the IC at deadline 1000, plus one when the first dispatch re-armed
   // at the same deadline 1000 (the cache fix forced this through). The second
   // dispatch contributes 0 (see comment above). Total: 2.
-  extra_failures += expect_eq_u64(
-      "[pinned] ic0_global_timer_set total scenario delta",
-      ic0mock_global_timer_set_call_count() - cnt_before, 2);
+  extra_failures +=
+      expect_eq_u64("[pinned] ic0_global_timer_set total scenario delta",
+                    ic0mock_global_timer_set_call_count() - cnt_before, 2);
 
   // Always clear the override before main() returns. Pattern A (this whole
   // runner uses exit_on_fail=false) means we reach this line even on

--- a/test/canisters/canister_timers/native/main.cpp
+++ b/test/canisters/canister_timers/native/main.cpp
@@ -250,8 +250,8 @@ int main() {
                   my_principal);
   uint64_t cnt_f = ic0mock_global_timer_set_call_count();
 
-  extra_failures += expect_eq_u64("[cancel-from-cb] T1 callback ran", t1_count,
-                                  1);
+  extra_failures +=
+      expect_eq_u64("[cancel-from-cb] T1 callback ran", t1_count, 1);
   extra_failures += expect_eq_u64(
       "[cancel-from-cb] T2 callback ran despite earlier cancel_all_timers",
       t2_count, 1);

--- a/test/canisters/canister_timers/native/main.cpp
+++ b/test/canisters/canister_timers/native/main.cpp
@@ -18,6 +18,12 @@
 #include "icpp_hooks.h"
 #include "mock_ic.h"
 
+// In the native build the include path resolves "ic0.h" to the ic0mock
+// header, which exposes the mock-only test helpers
+// (ic0mock_global_timer_set_call_count, ic0mock_set_time_override,
+// ic0mock_clear_time_override) used by the cache-stranding regression below.
+#include "ic0.h"
+
 #include "../src/my_canister.h"
 
 namespace {
@@ -38,7 +44,12 @@ int expect_eq_u64(const char *label, uint64_t actual, uint64_t expected) {
 } // namespace
 
 int main() {
-  bool exit_on_fail = true;
+  // exit_on_fail = false so a failing run_test does not call exit(1) and
+  // bypass the cleanup code below (in particular, ic0mock_clear_time_override
+  // calls in the time-pinned regression scenario). Failures are aggregated
+  // via mockIC.test_summary() + extra_failures; main() returns the OR of
+  // both at the end.
+  bool exit_on_fail = false;
   MockIC mockIC(exit_on_fail);
 
   std::string my_principal{
@@ -125,6 +136,81 @@ int main() {
                                   g_one_shot_count, before + 15);
   extra_failures += expect_eq_u64("registry empty after second drain",
                                   IcTimers::instance().size(), 0);
+
+  // ---- Cache-stranding regression (the High #1 bug from the rev1 review) --
+  // Without time-override, 15 successive set_timer(0,...) calls produce 15
+  // different deadlines (wall-clock advances between them) and the bug's
+  // exact pre-condition (remaining earliest deadline equals the
+  // previously-armed deadline) does not hold. We pin time so all 15 land at
+  // the same deadline, then dispatch and assert that arm_next() actually
+  // re-armed at the same deadline value. Without the fix in
+  // IcTimers::dispatch_due (which sets m_armed_deadline = 0 at entry),
+  // arm_next() would skip the syscall and the remaining 5 timers would be
+  // permanently stranded.
+  ic0mock_set_time_override(1000);
+  uint64_t cnt_before = ic0mock_global_timer_set_call_count();
+  uint64_t shots_before = g_one_shot_count;
+  for (int i = 0; i < 15; ++i) {
+    IC_API::set_timer(0, []() { ++g_one_shot_count; });
+  }
+  extra_failures +=
+      expect_eq_u64("[pinned] registry size before dispatch with 15 timers",
+                    IcTimers::instance().size(), 15);
+
+  // Advance the override past the deadline (which is 1000 + 0 = 1000).
+  ic0mock_set_time_override(2000);
+
+  // First dispatch: drain 10 of 15.
+  uint64_t cnt_a = ic0mock_global_timer_set_call_count();
+  mockIC.run_test("[pinned] canister_global_timer (drain 10 of 15)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  uint64_t cnt_b = ic0mock_global_timer_set_call_count();
+  extra_failures += expect_eq_u64(
+      "[pinned] ic0_global_timer_set call delta after first dispatch",
+      cnt_b - cnt_a, 1);
+  extra_failures +=
+      expect_eq_u64("[pinned] g_one_shot_count delta after first dispatch",
+                    g_one_shot_count - shots_before, 10);
+  extra_failures +=
+      expect_eq_u64("[pinned] registry size after first dispatch (5 left)",
+                    IcTimers::instance().size(), 5);
+
+  // Second dispatch: drain remaining 5 (under the 10-per-tick cap). Note
+  // we expect a delta of 0 here, not 1. After draining, the registry is
+  // empty, so arm_next() computes target = 0 ("disarm"). The cache fix
+  // also set m_armed_deadline = 0 at function entry, so target == cache
+  // and arm_next legitimately skips the syscall — disarming an already-
+  // disarmed IC is wasteful. The interesting assertion is the FIRST
+  // dispatch's delta above (which would be 0 without the cache fix and
+  // is 1 with it).
+  uint64_t cnt_c = ic0mock_global_timer_set_call_count();
+  mockIC.run_test("[pinned] canister_global_timer (drain remaining 5)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  uint64_t cnt_d = ic0mock_global_timer_set_call_count();
+  extra_failures += expect_eq_u64(
+      "[pinned] ic0_global_timer_set call delta after second dispatch (registry empty -> already disarmed -> skip)",
+      cnt_d - cnt_c, 0);
+  extra_failures +=
+      expect_eq_u64("[pinned] g_one_shot_count delta total", g_one_shot_count,
+                    shots_before + 15);
+  extra_failures +=
+      expect_eq_u64("[pinned] registry empty after second dispatch",
+                    IcTimers::instance().size(), 0);
+
+  // Total syscall count for the whole scenario: one when the first set_timer
+  // armed the IC at deadline 1000, plus one when the first dispatch re-armed
+  // at the same deadline 1000 (the cache fix forced this through). The second
+  // dispatch contributes 0 (see comment above). Total: 2.
+  extra_failures += expect_eq_u64(
+      "[pinned] ic0_global_timer_set total scenario delta",
+      ic0mock_global_timer_set_call_count() - cnt_before, 2);
+
+  // Always clear the override before main() returns. Pattern A (this whole
+  // runner uses exit_on_fail=false) means we reach this line even on
+  // assertion failure, so a single clear at scenario end is sufficient.
+  ic0mock_clear_time_override();
 
   std::cout << "\n----------\n";
   std::cout << "Extra direct-state assertions: "

--- a/test/canisters/canister_timers/native/main.cpp
+++ b/test/canisters/canister_timers/native/main.cpp
@@ -9,6 +9,7 @@
 #include "main.h"
 
 #include <iostream>
+#include <limits>
 
 // ic_api.h transitively pulls in canister.h, which declares the built-in
 // canister_global_timer() entry. Include it before the user's canister
@@ -284,6 +285,146 @@ int main() {
   extra_failures += expect_eq_u64(
       "[cancel-from-cb] T3 still 0 after second dispatch", t3_count, 0);
 
+  ic0mock_clear_time_override();
+
+  // ---- Motoko-style catch-up after a slow tick (recurring timers) ----------
+  // dispatch_due() recomputes the next deadline as
+  //   next = pivot + period * (skipped + 1)
+  // where  skipped = (now_ns - pivot) / period.  This block locks down both
+  // the "skipped == 0" trivial case (already covered above) and the
+  // "skipped >= 1" catch-up path, which the cancel-from-callback scenario
+  // does not exercise (it advances time exactly one period past pivot).
+  //
+  // We "simulate a slow tick" by jumping the time override forward by many
+  // periods before invoking canister_global_timer. The behavioral check is:
+  //   (a) the callback fires exactly ONCE per dispatch (no fire-storm), and
+  //   (b) the recomputed next deadline lands at pivot + (skipped+1)*period
+  //       — verified by dispatching at next-1 (no fire) and at next (fires).
+
+  // ---- Catch-up: skip a single period --------------------------------------
+  ic0mock_set_time_override(1000);
+  IC_API::cancel_all_timers();
+  uint64_t cu1_count = 0;
+  IC_API::set_timer_recurring(100, [&cu1_count]() { ++cu1_count; });
+  // pivot = 1000 + 100 = 1100. Jump to 1250: skipped = (1250-1100)/100 = 1,
+  // advance = 2, next = 1100 + 2*100 = 1300.
+  ic0mock_set_time_override(1250);
+  mockIC.run_test("[catch-up,skip=1] canister_global_timer at now=1250",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures +=
+      expect_eq_u64("[catch-up,skip=1] callback fired exactly once at slow tick",
+                    cu1_count, 1);
+  // Just before computed next deadline: must NOT fire.
+  ic0mock_set_time_override(1299);
+  mockIC.run_test("[catch-up,skip=1] canister_global_timer at now=next-1 (1299)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures += expect_eq_u64(
+      "[catch-up,skip=1] no fire at next-1 (proves next > now_ns of slow tick)",
+      cu1_count, 1);
+  // At computed next deadline: must fire exactly once more.
+  ic0mock_set_time_override(1300);
+  mockIC.run_test("[catch-up,skip=1] canister_global_timer at now=next (1300)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures += expect_eq_u64(
+      "[catch-up,skip=1] fire at next (locks down next == pivot + 2*period)",
+      cu1_count, 2);
+  IC_API::cancel_all_timers();
+  ic0mock_clear_time_override();
+
+  // ---- Catch-up: skip many periods (no fire-storm) -------------------------
+  ic0mock_set_time_override(0);
+  IC_API::cancel_all_timers();
+  uint64_t cu2_count = 0;
+  IC_API::set_timer_recurring(100, [&cu2_count]() { ++cu2_count; });
+  // pivot = 100, period = 100. Jump to 10_000: skipped = 99, advance = 100,
+  // next = 100 + 100*100 = 10_100. The bug-without-this-code would fire the
+  // callback ~100 times (once per missed period); the bug-without-the-+1
+  // would fire and reschedule next == 10_000 == now_ns, then fire again on
+  // the very next dispatch tick at the same now (tight loop).
+  ic0mock_set_time_override(10000);
+  mockIC.run_test("[catch-up,skip=99] canister_global_timer at now=10000",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures += expect_eq_u64(
+      "[catch-up,skip=99] callback fired exactly ONCE (no fire-storm)",
+      cu2_count, 1);
+  // Drive again at the same now — registry still has the recurring entry but
+  // its new deadline is 10_100, so nothing fires.
+  mockIC.run_test("[catch-up,skip=99] re-drive at now=10000 (next=10100)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures +=
+      expect_eq_u64("[catch-up,skip=99] no second fire at same now",
+                    cu2_count, 1);
+  ic0mock_set_time_override(10099);
+  mockIC.run_test("[catch-up,skip=99] canister_global_timer at next-1 (10099)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures += expect_eq_u64("[catch-up,skip=99] no fire at next-1",
+                                  cu2_count, 1);
+  ic0mock_set_time_override(10100);
+  mockIC.run_test("[catch-up,skip=99] canister_global_timer at next (10100)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures += expect_eq_u64(
+      "[catch-up,skip=99] fire at next (locks down next == pivot + 100*period)",
+      cu2_count, 2);
+  IC_API::cancel_all_timers();
+  ic0mock_clear_time_override();
+
+  // ---- Catch-up: pivot + increment overflow saturates to UINT64_MAX --------
+  // Adversarial scenario: pivot lands close to UINT64_MAX and adding one full
+  // period would overflow. The saturating_add in dispatch_due must clamp the
+  // new deadline to UINT64_MAX so the timer "never fires again" rather than
+  // wrapping into the past and refiring in a tight loop.
+  //
+  // Setup: now=100, period = UINT64_MAX-200. Registration deadline =
+  // saturating_add(100, UINT64_MAX-200) = UINT64_MAX-100 (no saturation; just
+  // arithmetic). Then jump now to UINT64_MAX-50: skipped = 50/(UINT64_MAX-200)
+  // = 0, advance = 1, increment = period*1 = UINT64_MAX-200, and
+  // next = saturating_add(UINT64_MAX-100, UINT64_MAX-200) saturates to
+  // UINT64_MAX. (We do not directly hit the period*advance overflow branch
+  // — that requires advance >= 2 with period > UINT64_MAX/advance, which is
+  // unreachable from a clean set_timer_recurring because registration would
+  // have saturated pivot to UINT64_MAX and the timer would never fire. The
+  // pivot+increment saturating_add below is what protects against fire-storm
+  // in the reachable adversarial case.)
+  constexpr uint64_t U64_MAX = std::numeric_limits<uint64_t>::max();
+  ic0mock_set_time_override(100);
+  IC_API::cancel_all_timers();
+  uint64_t cu3_count = 0;
+  IC_API::set_timer_recurring(U64_MAX - 200,
+                              [&cu3_count]() { ++cu3_count; });
+  extra_failures += expect_eq_u64("[catch-up,saturate] registered 1 recurring",
+                                  IcTimers::instance().size(), 1);
+
+  ic0mock_set_time_override(U64_MAX - 50);
+  mockIC.run_test("[catch-up,saturate] canister_global_timer at huge now",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures += expect_eq_u64(
+      "[catch-up,saturate] callback fired exactly once on overflow tick",
+      cu3_count, 1);
+
+  // Drive again at a time as close to UINT64_MAX as we can get. The
+  // recomputed next deadline saturated to UINT64_MAX, so it must remain
+  // strictly greater than any reachable now_ns we can pass to dispatch_due,
+  // and the callback must not fire again.
+  ic0mock_set_time_override(U64_MAX - 1);
+  mockIC.run_test(
+      "[catch-up,saturate] canister_global_timer at now = UINT64_MAX-1",
+      canister_global_timer, EMPTY_CANDID, "", silent_on_trap, my_principal);
+  extra_failures += expect_eq_u64(
+      "[catch-up,saturate] saturated next > now: no further fire",
+      cu3_count, 1);
+  extra_failures += expect_eq_u64(
+      "[catch-up,saturate] timer still in registry (recurring, not auto-cancelled)",
+      IcTimers::instance().size(), 1);
+
+  IC_API::cancel_all_timers();
   ic0mock_clear_time_override();
 
   std::cout << "\n----------\n";

--- a/test/canisters/canister_timers/native/main.cpp
+++ b/test/canisters/canister_timers/native/main.cpp
@@ -312,14 +312,14 @@ int main() {
   mockIC.run_test("[catch-up,skip=1] canister_global_timer at now=1250",
                   canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
                   my_principal);
-  extra_failures +=
-      expect_eq_u64("[catch-up,skip=1] callback fired exactly once at slow tick",
-                    cu1_count, 1);
+  extra_failures += expect_eq_u64(
+      "[catch-up,skip=1] callback fired exactly once at slow tick", cu1_count,
+      1);
   // Just before computed next deadline: must NOT fire.
   ic0mock_set_time_override(1299);
-  mockIC.run_test("[catch-up,skip=1] canister_global_timer at now=next-1 (1299)",
-                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
-                  my_principal);
+  mockIC.run_test(
+      "[catch-up,skip=1] canister_global_timer at now=next-1 (1299)",
+      canister_global_timer, EMPTY_CANDID, "", silent_on_trap, my_principal);
   extra_failures += expect_eq_u64(
       "[catch-up,skip=1] no fire at next-1 (proves next > now_ns of slow tick)",
       cu1_count, 1);
@@ -356,15 +356,14 @@ int main() {
   mockIC.run_test("[catch-up,skip=99] re-drive at now=10000 (next=10100)",
                   canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
                   my_principal);
-  extra_failures +=
-      expect_eq_u64("[catch-up,skip=99] no second fire at same now",
-                    cu2_count, 1);
+  extra_failures += expect_eq_u64(
+      "[catch-up,skip=99] no second fire at same now", cu2_count, 1);
   ic0mock_set_time_override(10099);
   mockIC.run_test("[catch-up,skip=99] canister_global_timer at next-1 (10099)",
                   canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
                   my_principal);
-  extra_failures += expect_eq_u64("[catch-up,skip=99] no fire at next-1",
-                                  cu2_count, 1);
+  extra_failures +=
+      expect_eq_u64("[catch-up,skip=99] no fire at next-1", cu2_count, 1);
   ic0mock_set_time_override(10100);
   mockIC.run_test("[catch-up,skip=99] canister_global_timer at next (10100)",
                   canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
@@ -396,8 +395,7 @@ int main() {
   ic0mock_set_time_override(100);
   IC_API::cancel_all_timers();
   uint64_t cu3_count = 0;
-  IC_API::set_timer_recurring(U64_MAX - 200,
-                              [&cu3_count]() { ++cu3_count; });
+  IC_API::set_timer_recurring(U64_MAX - 200, [&cu3_count]() { ++cu3_count; });
   extra_failures += expect_eq_u64("[catch-up,saturate] registered 1 recurring",
                                   IcTimers::instance().size(), 1);
 
@@ -417,9 +415,9 @@ int main() {
   mockIC.run_test(
       "[catch-up,saturate] canister_global_timer at now = UINT64_MAX-1",
       canister_global_timer, EMPTY_CANDID, "", silent_on_trap, my_principal);
-  extra_failures += expect_eq_u64(
-      "[catch-up,saturate] saturated next > now: no further fire",
-      cu3_count, 1);
+  extra_failures +=
+      expect_eq_u64("[catch-up,saturate] saturated next > now: no further fire",
+                    cu3_count, 1);
   extra_failures += expect_eq_u64(
       "[catch-up,saturate] timer still in registry (recurring, not auto-cancelled)",
       IcTimers::instance().size(), 1);

--- a/test/canisters/canister_timers/native/main.cpp
+++ b/test/canisters/canister_timers/native/main.cpp
@@ -211,6 +211,78 @@ int main() {
   // assertion failure, so a single clear at scenario end is sufficient.
   ic0mock_clear_time_override();
 
+  // ---- Cancel-all-from-callback test (commit 4) -------------------------
+  // Locks down the documented current-dispatch semantics: callbacks already
+  // collected into the in-flight dispatch_due() batch (copied into the
+  // local `to_run` vector before any callback ran) STILL execute even after
+  // a callback calls cancel_all_timers() mid-batch. Future firings, and
+  // any recurring timer's next-deadline rescheduling, are cancelled.
+  //
+  // Time is pinned (per reviewer) so all 3 recurring timers compute the
+  // same deadline and are guaranteed due in a single dispatch batch — wall-
+  // clock drift between successive set_timer_recurring calls would
+  // otherwise give them slightly different deadlines.
+  //
+  // Registration order is the test's intent: the cancelling timer is
+  // registered FIRST so its callback lands at the front of `to_run`. We
+  // want to prove that the OTHER two callbacks, copied into `to_run`
+  // before the cancel ran, still execute. Registering the cancelling
+  // timer last would prove nothing about post-cancel callback execution.
+  ic0mock_set_time_override(1000);
+  // Reset counters from earlier scenarios so the asserts below are scoped.
+  IC_API::cancel_all_timers();
+  uint64_t t1_count = 0, t2_count = 0, t3_count = 0;
+  IC_API::set_timer_recurring(100, [&t1_count]() {
+    ++t1_count;
+    IC_API::cancel_all_timers();
+  });
+  IC_API::set_timer_recurring(100, [&t2_count]() { ++t2_count; });
+  IC_API::set_timer_recurring(100, [&t3_count]() { ++t3_count; });
+  extra_failures += expect_eq_u64(
+      "[cancel-from-cb] registry size after registering 3 recurring",
+      IcTimers::instance().size(), 3);
+
+  // Advance past the deadline (1000 + 100 = 1100).
+  ic0mock_set_time_override(1100);
+  uint64_t cnt_e = ic0mock_global_timer_set_call_count();
+  mockIC.run_test("[cancel-from-cb] canister_global_timer",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  uint64_t cnt_f = ic0mock_global_timer_set_call_count();
+
+  extra_failures += expect_eq_u64("[cancel-from-cb] T1 callback ran", t1_count,
+                                  1);
+  extra_failures += expect_eq_u64(
+      "[cancel-from-cb] T2 callback ran despite earlier cancel_all_timers",
+      t2_count, 1);
+  extra_failures += expect_eq_u64(
+      "[cancel-from-cb] T3 callback ran despite earlier cancel_all_timers",
+      t3_count, 1);
+  extra_failures +=
+      expect_eq_u64("[cancel-from-cb] registry empty after dispatch",
+                    IcTimers::instance().size(), 0);
+  // The clear()'s unconditional ic0_global_timer_set(0) should show in the
+  // mock counter delta during this dispatch. The dispatch's final arm_next
+  // sees an empty registry (target=0) matching the cache (also 0 after the
+  // top-of-dispatch invalidation), so it skips. Net delta: 1 syscall from
+  // clear()'s explicit disarm.
+  extra_failures += expect_eq_u64(
+      "[cancel-from-cb] ic0_global_timer_set delta (clear's disarm)",
+      cnt_f - cnt_e, 1);
+
+  // Drive again — registry is empty so no callbacks should fire.
+  mockIC.run_test("[cancel-from-cb] canister_global_timer (second, no-op)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures +=
+      expect_eq_u64("[cancel-from-cb] T1 did not fire again", t1_count, 1);
+  extra_failures +=
+      expect_eq_u64("[cancel-from-cb] T2 did not fire again", t2_count, 1);
+  extra_failures +=
+      expect_eq_u64("[cancel-from-cb] T3 did not fire again", t3_count, 1);
+
+  ic0mock_clear_time_override();
+
   std::cout << "\n----------\n";
   std::cout << "Extra direct-state assertions: "
             << (extra_failures == 0 ? "all PASSED" : "some FAILED")

--- a/test/canisters/canister_timers/native/main.cpp
+++ b/test/canisters/canister_timers/native/main.cpp
@@ -224,10 +224,13 @@ int main() {
   // otherwise give them slightly different deadlines.
   //
   // Registration order is the test's intent: the cancelling timer is
-  // registered FIRST so its callback lands at the front of `to_run`. We
-  // want to prove that the OTHER two callbacks, copied into `to_run`
-  // before the cancel ran, still execute. Registering the cancelling
-  // timer last would prove nothing about post-cancel callback execution.
+  // registered FIRST so its callback runs first in this batch. After T1
+  // calls cancel_all_timers(), T2 and T3 — which are also "due" in this
+  // batch but have not yet run — must NOT fire, because dispatch_due
+  // looks them up in m_by_id at execute time and sees clear() removed
+  // them. (Earlier semantics copied callbacks into the batch up front and
+  // would have fired T2 and T3 anyway; that was observably-wrong cancel
+  // behavior and was changed in response to PR review.)
   ic0mock_set_time_override(1000);
   // Reset counters from earlier scenarios so the asserts below are scoped.
   IC_API::cancel_all_timers();
@@ -253,11 +256,11 @@ int main() {
   extra_failures +=
       expect_eq_u64("[cancel-from-cb] T1 callback ran", t1_count, 1);
   extra_failures += expect_eq_u64(
-      "[cancel-from-cb] T2 callback ran despite earlier cancel_all_timers",
-      t2_count, 1);
+      "[cancel-from-cb] T2 callback was cancelled mid-batch (did NOT run)",
+      t2_count, 0);
   extra_failures += expect_eq_u64(
-      "[cancel-from-cb] T3 callback ran despite earlier cancel_all_timers",
-      t3_count, 1);
+      "[cancel-from-cb] T3 callback was cancelled mid-batch (did NOT run)",
+      t3_count, 0);
   extra_failures +=
       expect_eq_u64("[cancel-from-cb] registry empty after dispatch",
                     IcTimers::instance().size(), 0);
@@ -276,10 +279,10 @@ int main() {
                   my_principal);
   extra_failures +=
       expect_eq_u64("[cancel-from-cb] T1 did not fire again", t1_count, 1);
-  extra_failures +=
-      expect_eq_u64("[cancel-from-cb] T2 did not fire again", t2_count, 1);
-  extra_failures +=
-      expect_eq_u64("[cancel-from-cb] T3 did not fire again", t3_count, 1);
+  extra_failures += expect_eq_u64(
+      "[cancel-from-cb] T2 still 0 after second dispatch", t2_count, 0);
+  extra_failures += expect_eq_u64(
+      "[cancel-from-cb] T3 still 0 after second dispatch", t3_count, 0);
 
   ic0mock_clear_time_override();
 

--- a/test/canisters/canister_timers/native/main.cpp
+++ b/test/canisters/canister_timers/native/main.cpp
@@ -1,0 +1,136 @@
+// Native test driver for the canister_timers test canister.
+// Build with: `icpp build-native` and run `./build-native/mockic.exe`.
+//
+// We exercise the timer-dispatch path by calling canister_global_timer
+// directly through MockIC, since the Mock IC does not actually fire timers
+// on its own. Counter state is read via the extern globals declared in
+// my_canister.h to avoid candid round-tripping.
+
+#include "main.h"
+
+#include <iostream>
+
+// ic_api.h transitively pulls in canister.h, which declares the built-in
+// canister_global_timer() entry. Include it before the user's canister
+// header so the canister_*.h forward-declaration chain is fully resolved.
+#include "ic_api.h"
+#include "ic_timers.h"
+#include "icpp_hooks.h"
+#include "mock_ic.h"
+
+#include "../src/my_canister.h"
+
+namespace {
+
+// Minimal candid for "()" (DIDL header, 0 types, 0 args).
+constexpr const char *EMPTY_CANDID = "4449444c0000";
+
+int expect_eq_u64(const char *label, uint64_t actual, uint64_t expected) {
+  if (actual != expected) {
+    std::cout << "FAIL: " << label << " expected " << expected << ", got "
+              << actual << std::endl;
+    return 1;
+  }
+  std::cout << "PASS: " << label << " == " << actual << std::endl;
+  return 0;
+}
+
+} // namespace
+
+int main() {
+  bool exit_on_fail = true;
+  MockIC mockIC(exit_on_fail);
+
+  std::string my_principal{
+      "expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae"};
+  bool silent_on_trap = true;
+
+  int extra_failures = 0;
+
+  // Pass empty candid_out_expected (""), which makes MockIC accept whatever
+  // the function writes back. We validate state directly via the extern
+  // globals and IcTimers::instance().size().
+  mockIC.run_test("canister_init", canister_init, EMPTY_CANDID, "",
+                  silent_on_trap, my_principal);
+
+  // ---- one-shot fires after a dispatch tick ----------------------------
+  mockIC.run_test("start_one_shot", start_one_shot, EMPTY_CANDID, "",
+                  silent_on_trap, my_principal);
+  extra_failures += expect_eq_u64("registry size after start_one_shot",
+                                  IcTimers::instance().size(), 1);
+
+  mockIC.run_test("canister_global_timer (drain one-shot)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures += expect_eq_u64("g_one_shot_count", g_one_shot_count, 1);
+  extra_failures += expect_eq_u64("registry size after dispatch",
+                                  IcTimers::instance().size(), 0);
+
+  // ---- a second dispatch with no due timers is a no-op -----------------
+  mockIC.run_test("canister_global_timer (no-op when empty)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures +=
+      expect_eq_u64("g_one_shot_count after no-op", g_one_shot_count, 1);
+
+  // ---- cancel removes the timer without firing -------------------------
+  // Add a one-shot, capture the id, cancel it, dispatch — counter unchanged.
+  uint64_t to_cancel = IC_API::set_timer(0, []() { ++g_one_shot_count; });
+  extra_failures += expect_eq_u64("registry size after manual set_timer",
+                                  IcTimers::instance().size(), 1);
+  bool ok = IC_API::cancel_timer(to_cancel);
+  if (!ok) {
+    std::cout << "FAIL: cancel_timer returned false" << std::endl;
+    ++extra_failures;
+  } else {
+    std::cout << "PASS: cancel_timer returned true" << std::endl;
+  }
+  extra_failures += expect_eq_u64("registry size after cancel",
+                                  IcTimers::instance().size(), 0);
+
+  mockIC.run_test("canister_global_timer (after cancel)", canister_global_timer,
+                  EMPTY_CANDID, "", silent_on_trap, my_principal);
+  extra_failures +=
+      expect_eq_u64("g_one_shot_count after cancel", g_one_shot_count, 1);
+
+  // Cancelling an unknown id returns false.
+  if (IC_API::cancel_timer(99999)) {
+    std::cout << "FAIL: cancel_timer(99999) should return false" << std::endl;
+    ++extra_failures;
+  } else {
+    std::cout << "PASS: cancel_timer(unknown) returns false" << std::endl;
+  }
+
+  // ---- many one-shots fire in deadline order, capped at 10 per tick ----
+  for (int i = 0; i < 15; ++i) {
+    IC_API::set_timer(0, []() { ++g_one_shot_count; });
+  }
+  extra_failures += expect_eq_u64("registry size with 15 timers",
+                                  IcTimers::instance().size(), 15);
+  uint64_t before = g_one_shot_count;
+
+  mockIC.run_test("canister_global_timer (drain 10 of 15)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures += expect_eq_u64("g_one_shot_count after first drain",
+                                  g_one_shot_count, before + 10);
+  extra_failures +=
+      expect_eq_u64("registry size after first drain (5 remaining)",
+                    IcTimers::instance().size(), 5);
+
+  mockIC.run_test("canister_global_timer (drain remaining 5)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures += expect_eq_u64("g_one_shot_count after second drain",
+                                  g_one_shot_count, before + 15);
+  extra_failures += expect_eq_u64("registry empty after second drain",
+                                  IcTimers::instance().size(), 0);
+
+  std::cout << "\n----------\n";
+  std::cout << "Extra direct-state assertions: "
+            << (extra_failures == 0 ? "all PASSED" : "some FAILED")
+            << std::endl;
+
+  int summary_rc = mockIC.test_summary();
+  return summary_rc != 0 ? summary_rc : (extra_failures > 0 ? 1 : 0);
+}

--- a/test/canisters/canister_timers/native/main.h
+++ b/test/canisters/canister_timers/native/main.h
@@ -1,0 +1,2 @@
+// Main entry point for a native debug executable.
+// Build it with: `icpp build-native` from the parent folder where 'icpp.toml' resides

--- a/test/canisters/canister_timers/src/my_canister.cpp
+++ b/test/canisters/canister_timers/src/my_canister.cpp
@@ -1,0 +1,82 @@
+// A minimal canister demonstrating IC_API timer support.
+//
+// - start_one_shot()           : schedules a one-shot that increments
+//                                g_one_shot_count after a tiny delay.
+// - start_recurring(period_ns) : schedules a recurring timer that
+//                                increments g_recurring_count every period.
+// - stop_timer(id)             : cancels a previously registered timer.
+// - get_*                      : query counters / registry size.
+// - reset_counts()             : zero counters and cancel all timers.
+
+#include "my_canister.h"
+
+#include <string>
+
+#include "ic_api.h"
+#include "ic_timers.h"
+
+uint64_t g_one_shot_count{0};
+uint64_t g_recurring_count{0};
+
+namespace {
+// One-shot delay used by start_one_shot. Zero so the deadline lands at "now"
+// and the next canister_global_timer tick will fire it — both on the IC and
+// in the native MockIC driver.
+constexpr uint64_t ONE_SHOT_DELAY_NS = 0;
+} // namespace
+
+void canister_init() {
+  IC_API ic_api(CanisterInit{std::string(__func__)}, false);
+}
+
+void start_one_shot() {
+  IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
+  ic_api.from_wire();
+  uint64_t id =
+      IC_API::set_timer(ONE_SHOT_DELAY_NS, []() { ++g_one_shot_count; });
+  ic_api.to_wire(CandidTypeNat64{id});
+}
+
+void start_recurring() {
+  IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
+  uint64_t period_ns{0};
+  ic_api.from_wire(CandidTypeNat64{&period_ns});
+  uint64_t id =
+      IC_API::set_timer_recurring(period_ns, []() { ++g_recurring_count; });
+  ic_api.to_wire(CandidTypeNat64{id});
+}
+
+void stop_timer() {
+  IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
+  uint64_t id{0};
+  ic_api.from_wire(CandidTypeNat64{&id});
+  bool ok = IC_API::cancel_timer(id);
+  ic_api.to_wire(CandidTypeBool{ok});
+}
+
+void reset_counts() {
+  IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
+  ic_api.from_wire();
+  g_one_shot_count = 0;
+  g_recurring_count = 0;
+  ic_api.to_wire();
+}
+
+void get_one_shot_count() {
+  IC_API ic_api(CanisterQuery{std::string(__func__)}, false);
+  ic_api.from_wire();
+  ic_api.to_wire(CandidTypeNat64{g_one_shot_count});
+}
+
+void get_recurring_count() {
+  IC_API ic_api(CanisterQuery{std::string(__func__)}, false);
+  ic_api.from_wire();
+  ic_api.to_wire(CandidTypeNat64{g_recurring_count});
+}
+
+void get_timer_count() {
+  IC_API ic_api(CanisterQuery{std::string(__func__)}, false);
+  ic_api.from_wire();
+  ic_api.to_wire(
+      CandidTypeNat64{static_cast<uint64_t>(IcTimers::instance().size())});
+}

--- a/test/canisters/canister_timers/src/my_canister.cpp
+++ b/test/canisters/canister_timers/src/my_canister.cpp
@@ -59,6 +59,10 @@ void reset_counts() {
   ic_api.from_wire();
   g_one_shot_count = 0;
   g_recurring_count = 0;
+  // Cancel every registered timer too — the docstring at the top of this
+  // file says reset_counts "zeros counters and cancels all timers", and
+  // pytest scenarios depend on a clean registry between scenarios.
+  IC_API::cancel_all_timers();
   ic_api.to_wire();
 }
 

--- a/test/canisters/canister_timers/src/my_canister.cpp
+++ b/test/canisters/canister_timers/src/my_canister.cpp
@@ -18,12 +18,9 @@
 uint64_t g_one_shot_count{0};
 uint64_t g_recurring_count{0};
 
-namespace {
 // One-shot delay used by start_one_shot. Zero so the deadline lands at "now"
-// and the next canister_global_timer tick will fire it — both on the IC and
-// in the native MockIC driver.
+// and the next canister_global_timer tick will fire it.
 constexpr uint64_t ONE_SHOT_DELAY_NS = 0;
-} // namespace
 
 void canister_init() {
   IC_API ic_api(CanisterInit{std::string(__func__)}, false);

--- a/test/canisters/canister_timers/src/my_canister.did
+++ b/test/canisters/canister_timers/src/my_canister.did
@@ -1,0 +1,9 @@
+service : {
+  start_one_shot : () -> (nat64);
+  start_recurring : (nat64) -> (nat64);
+  stop_timer : (nat64) -> (bool);
+  get_one_shot_count : () -> (nat64) query;
+  get_recurring_count : () -> (nat64) query;
+  get_timer_count : () -> (nat64) query;
+  reset_counts : () -> ();
+}

--- a/test/canisters/canister_timers/src/my_canister.h
+++ b/test/canisters/canister_timers/src/my_canister.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+
+#include "wasm_symbol.h"
+
+// Counters and ids exposed for the native test driver to inspect directly,
+// without round-tripping through Candid.
+extern uint64_t g_one_shot_count;
+extern uint64_t g_recurring_count;
+
+void canister_init() WASM_SYMBOL_EXPORTED("canister_init");
+
+void start_one_shot() WASM_SYMBOL_EXPORTED("canister_update start_one_shot");
+void start_recurring() WASM_SYMBOL_EXPORTED("canister_update start_recurring");
+void stop_timer() WASM_SYMBOL_EXPORTED("canister_update stop_timer");
+void reset_counts() WASM_SYMBOL_EXPORTED("canister_update reset_counts");
+
+void get_one_shot_count()
+    WASM_SYMBOL_EXPORTED("canister_query get_one_shot_count");
+void get_recurring_count()
+    WASM_SYMBOL_EXPORTED("canister_query get_recurring_count");
+void get_timer_count() WASM_SYMBOL_EXPORTED("canister_query get_timer_count");

--- a/test/canisters/canister_timers/test/conftest.py
+++ b/test/canisters/canister_timers/test/conftest.py
@@ -4,4 +4,4 @@
 
 # pylint: disable=missing-function-docstring, unused-import, wildcard-import, unused-wildcard-import, line-too-long, unused-argument
 import pytest
-from icpp.conftest_base import *  # pytest fixtures provided by icpp-pro
+from icpp.conftest_base import *  # noqa: F403  # pytest fixtures provided by icpp-pro

--- a/test/canisters/canister_timers/test/conftest.py
+++ b/test/canisters/canister_timers/test/conftest.py
@@ -1,0 +1,7 @@
+"""The pytest fixtures
+   https://docs.pytest.org/en/latest/fixture.html
+"""
+
+# pylint: disable=missing-function-docstring, unused-import, wildcard-import, unused-wildcard-import, line-too-long, unused-argument
+import pytest
+from icpp.conftest_base import *  # pytest fixtures provided by icpp-pro

--- a/test/canisters/canister_timers/test/test_apis.py
+++ b/test/canisters/canister_timers/test/test_apis.py
@@ -129,3 +129,59 @@ def test__cancel_unknown_returns_false(network: str, principal: str) -> None:
         network=network,
     )
     assert "false" in response
+
+
+def test__reset_counts_cancels_recurring_timer(
+    network: str, principal: str
+) -> None:
+    """Leak-proof reset (commit 4): reset_counts now cancels every
+    registered timer in addition to zeroing counters. After reset, a
+    previously-registered recurring timer must NOT continue to fire."""
+    _reset(network)
+
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="start_recurring",
+        canister_argument="(1_000_000_000 : nat64)",
+        network=network,
+    )
+    timer_id = _parse_nat64(response)
+    assert timer_id > 0
+
+    time.sleep(2.5)
+    initial_count = _parse_nat64(
+        call_canister_api(
+            dfx_json_path=DFX_JSON_PATH,
+            canister_name=CANISTER_NAME,
+            canister_method="get_recurring_count",
+            network=network,
+        )
+    )
+    assert initial_count >= 2, (
+        f"recurring timer was not firing; expected >=2 ticks in 2.5s, "
+        f"got {initial_count}"
+    )
+
+    # reset_counts now also calls IC_API::cancel_all_timers().
+    call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="reset_counts",
+        network=network,
+    )
+
+    # Sleep long enough that, if the timer leaked, the count would advance.
+    time.sleep(3.0)
+    after_reset_count = _parse_nat64(
+        call_canister_api(
+            dfx_json_path=DFX_JSON_PATH,
+            canister_name=CANISTER_NAME,
+            canister_method="get_recurring_count",
+            network=network,
+        )
+    )
+    assert after_reset_count == 0, (
+        f"recurring timer leaked across reset: count grew to "
+        f"{after_reset_count} after reset_counts"
+    )

--- a/test/canisters/canister_timers/test/test_apis.py
+++ b/test/canisters/canister_timers/test/test_apis.py
@@ -131,9 +131,7 @@ def test__cancel_unknown_returns_false(network: str, principal: str) -> None:
     assert "false" in response
 
 
-def test__reset_counts_cancels_recurring_timer(
-    network: str, principal: str
-) -> None:
+def test__reset_counts_cancels_recurring_timer(network: str, principal: str) -> None:
     """Leak-proof reset (commit 4): reset_counts now cancels every
     registered timer in addition to zeroing counters. After reset, a
     previously-registered recurring timer must NOT continue to fire."""

--- a/test/canisters/canister_timers/test/test_apis.py
+++ b/test/canisters/canister_timers/test/test_apis.py
@@ -10,6 +10,7 @@
 import re
 import time
 from pathlib import Path
+from typing import Callable
 
 import pytest
 
@@ -28,6 +29,47 @@ def _parse_nat64(response: str) -> int:
     return int(m.group(1).replace("_", ""))
 
 
+def _parse_bool(response: str) -> bool:
+    # Candid `(bool)` reply renders as exactly "(true)" or "(false)" (with
+    # optional surrounding whitespace). A substring check on "true" / "false"
+    # would also match unrelated text in error responses, so anchor the match.
+    m = re.search(r"\(\s*(true|false)\s*\)", response)
+    if not m:
+        pytest.fail(f"could not parse bool from response: {response!r}")
+    return m.group(1) == "true"
+
+
+def _poll_count(
+    network: str,
+    method: str,
+    predicate: Callable[[int], bool],
+    timeout_s: float = 10.0,
+    interval_s: float = 0.2,
+) -> int:
+    """Repeatedly query a `() -> (nat64) query` method until `predicate(count)`
+    returns True or the deadline is reached. Returns the last observed count.
+
+    Avoids fixed sleeps that have to be tuned to the slowest realistic
+    replica. CI pytest runs on shared infrastructure where a 3 s sleep can
+    be both flaky-too-short on a busy box and wasteful on a quiet one;
+    polling adapts."""
+    deadline = time.time() + timeout_s
+    count = 0
+    while time.time() < deadline:
+        count = _parse_nat64(
+            call_canister_api(
+                dfx_json_path=DFX_JSON_PATH,
+                canister_name=CANISTER_NAME,
+                canister_method=method,
+                network=network,
+            )
+        )
+        if predicate(count):
+            return count
+        time.sleep(interval_s)
+    return count
+
+
 def _reset(network: str) -> None:
     call_canister_api(
         dfx_json_path=DFX_JSON_PATH,
@@ -40,8 +82,6 @@ def _reset(network: str) -> None:
 def test__one_shot_fires(network: str, principal: str) -> None:
     _reset(network)
 
-    # Schedule a one-shot timer (delay = 0). The IC will fire
-    # canister_global_timer almost immediately; give it a moment.
     response = call_canister_api(
         dfx_json_path=DFX_JSON_PATH,
         canister_name=CANISTER_NAME,
@@ -51,22 +91,7 @@ def test__one_shot_fires(network: str, principal: str) -> None:
     timer_id = _parse_nat64(response)
     assert timer_id > 0
 
-    # The IC schedules canister_global_timer asynchronously. Poll for up to
-    # 10 seconds for the counter to advance.
-    deadline = time.time() + 10
-    count = 0
-    while time.time() < deadline:
-        response = call_canister_api(
-            dfx_json_path=DFX_JSON_PATH,
-            canister_name=CANISTER_NAME,
-            canister_method="get_one_shot_count",
-            network=network,
-        )
-        count = _parse_nat64(response)
-        if count >= 1:
-            break
-        time.sleep(0.5)
-
+    count = _poll_count(network, "get_one_shot_count", lambda c: c >= 1)
     assert count == 1, f"one-shot did not fire (count={count})"
 
 
@@ -84,19 +109,13 @@ def test__recurring_fires_and_can_be_cancelled(network: str, principal: str) -> 
     timer_id = _parse_nat64(response)
     assert timer_id > 0
 
-    # Wait ~3.5 seconds; expect at least 3 firings.
-    time.sleep(3.5)
-    response = call_canister_api(
-        dfx_json_path=DFX_JSON_PATH,
-        canister_name=CANISTER_NAME,
-        canister_method="get_recurring_count",
-        network=network,
+    # Poll until we observe at least 3 firings (or hit the deadline).
+    after_three = _poll_count(
+        network, "get_recurring_count", lambda c: c >= 3, timeout_s=15.0
     )
-    after_three = _parse_nat64(response)
     assert after_three >= 3, f"expected >=3 firings, got {after_three}"
 
-    # Cancel and verify the count stops growing (allow at most one
-    # additional in-flight firing tick).
+    # Cancel.
     response = call_canister_api(
         dfx_json_path=DFX_JSON_PATH,
         canister_name=CANISTER_NAME,
@@ -104,16 +123,21 @@ def test__recurring_fires_and_can_be_cancelled(network: str, principal: str) -> 
         canister_argument=f"({timer_id} : nat64)",
         network=network,
     )
-    assert "true" in response
+    assert _parse_bool(response) is True
 
+    # Quietness check still requires a wall-clock wait — there's no faster
+    # way to be sure something *isn't* happening — but we keep it short and
+    # allow at most one additional in-flight firing tick that may have been
+    # in the pipeline when cancel landed.
     time.sleep(2.5)
-    response = call_canister_api(
-        dfx_json_path=DFX_JSON_PATH,
-        canister_name=CANISTER_NAME,
-        canister_method="get_recurring_count",
-        network=network,
+    after_cancel = _parse_nat64(
+        call_canister_api(
+            dfx_json_path=DFX_JSON_PATH,
+            canister_name=CANISTER_NAME,
+            canister_method="get_recurring_count",
+            network=network,
+        )
     )
-    after_cancel = _parse_nat64(response)
     assert after_cancel <= after_three + 1, (
         f"recurring did not stop after cancel: "
         f"after_three={after_three}, after_cancel={after_cancel}"
@@ -128,7 +152,7 @@ def test__cancel_unknown_returns_false(network: str, principal: str) -> None:
         canister_argument="(999_999 : nat64)",
         network=network,
     )
-    assert "false" in response
+    assert _parse_bool(response) is False
 
 
 def test__reset_counts_cancels_recurring_timer(network: str, principal: str) -> None:
@@ -147,17 +171,11 @@ def test__reset_counts_cancels_recurring_timer(network: str, principal: str) -> 
     timer_id = _parse_nat64(response)
     assert timer_id > 0
 
-    time.sleep(2.5)
-    initial_count = _parse_nat64(
-        call_canister_api(
-            dfx_json_path=DFX_JSON_PATH,
-            canister_name=CANISTER_NAME,
-            canister_method="get_recurring_count",
-            network=network,
-        )
+    initial_count = _poll_count(
+        network, "get_recurring_count", lambda c: c >= 2, timeout_s=10.0
     )
     assert initial_count >= 2, (
-        f"recurring timer was not firing; expected >=2 ticks in 2.5s, "
+        f"recurring timer was not firing; expected >=2 ticks within poll window, "
         f"got {initial_count}"
     )
 
@@ -169,7 +187,9 @@ def test__reset_counts_cancels_recurring_timer(network: str, principal: str) -> 
         network=network,
     )
 
-    # Sleep long enough that, if the timer leaked, the count would advance.
+    # Quietness check: wait long enough that, if the timer leaked, the
+    # count would advance. Fixed sleep is the right shape here — we're
+    # asserting non-occurrence, not waiting for an event.
     time.sleep(3.0)
     after_reset_count = _parse_nat64(
         call_canister_api(

--- a/test/canisters/canister_timers/test/test_apis.py
+++ b/test/canisters/canister_timers/test/test_apis.py
@@ -1,0 +1,131 @@
+"""Test canister APIs for canister_timers.
+
+   First deploy the canister, then run:
+
+   $ pytest --network=[local/ic]
+"""
+
+# pylint: disable=missing-function-docstring, unused-import, wildcard-import, unused-wildcard-import
+
+import re
+import time
+from pathlib import Path
+
+import pytest
+
+from icpp.smoketest import call_canister_api
+
+DFX_JSON_PATH = Path(__file__).parent / "../dfx.json"
+CANISTER_NAME = "my_canister"
+
+
+def _parse_nat64(response: str) -> int:
+    # Candid output looks like: "(123 : nat64)"  — possibly with underscores
+    # in the integer literal for grouping.
+    m = re.search(r"\(\s*([0-9_]+)\s*:\s*nat64\s*\)", response)
+    if not m:
+        pytest.fail(f"could not parse nat64 from response: {response!r}")
+    return int(m.group(1).replace("_", ""))
+
+
+def _reset(network: str) -> None:
+    call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="reset_counts",
+        network=network,
+    )
+
+
+def test__one_shot_fires(network: str, principal: str) -> None:
+    _reset(network)
+
+    # Schedule a one-shot timer (delay = 0). The IC will fire
+    # canister_global_timer almost immediately; give it a moment.
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="start_one_shot",
+        network=network,
+    )
+    timer_id = _parse_nat64(response)
+    assert timer_id > 0
+
+    # The IC schedules canister_global_timer asynchronously. Poll for up to
+    # 10 seconds for the counter to advance.
+    deadline = time.time() + 10
+    count = 0
+    while time.time() < deadline:
+        response = call_canister_api(
+            dfx_json_path=DFX_JSON_PATH,
+            canister_name=CANISTER_NAME,
+            canister_method="get_one_shot_count",
+            network=network,
+        )
+        count = _parse_nat64(response)
+        if count >= 1:
+            break
+        time.sleep(0.5)
+
+    assert count == 1, f"one-shot did not fire (count={count})"
+
+
+def test__recurring_fires_and_can_be_cancelled(network: str, principal: str) -> None:
+    _reset(network)
+
+    # Schedule a recurring timer with period 1s.
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="start_recurring",
+        canister_argument="(1_000_000_000 : nat64)",
+        network=network,
+    )
+    timer_id = _parse_nat64(response)
+    assert timer_id > 0
+
+    # Wait ~3.5 seconds; expect at least 3 firings.
+    time.sleep(3.5)
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="get_recurring_count",
+        network=network,
+    )
+    after_three = _parse_nat64(response)
+    assert after_three >= 3, f"expected >=3 firings, got {after_three}"
+
+    # Cancel and verify the count stops growing (allow at most one
+    # additional in-flight firing tick).
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="stop_timer",
+        canister_argument=f"({timer_id} : nat64)",
+        network=network,
+    )
+    assert "true" in response
+
+    time.sleep(2.5)
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="get_recurring_count",
+        network=network,
+    )
+    after_cancel = _parse_nat64(response)
+    assert after_cancel <= after_three + 1, (
+        f"recurring did not stop after cancel: "
+        f"after_three={after_three}, after_cancel={after_cancel}"
+    )
+
+
+def test__cancel_unknown_returns_false(network: str, principal: str) -> None:
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="stop_timer",
+        canister_argument="(999_999 : nat64)",
+        network=network,
+    )
+    assert "false" in response

--- a/test/canisters/canister_user_timer_override/dfx.json
+++ b/test/canisters/canister_user_timer_override/dfx.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "canisters": {
+    "my_canister": {
+      "type": "custom",
+      "candid": "build/my_canister.did",
+      "wasm": "build/my_canister.wasm"
+    }
+  },
+  "defaults": {
+    "build": {
+      "args": "",
+      "packtool": ""
+    }
+  }
+}

--- a/test/canisters/canister_user_timer_override/icpp.toml
+++ b/test/canisters/canister_user_timer_override/icpp.toml
@@ -1,0 +1,15 @@
+[build-wasm]
+canister = "my_canister"
+did_path = "src/my_canister.did"
+cpp_paths = ["src/*.cpp"]
+cpp_include_dirs = []
+cpp_compile_flags = []
+cpp_link_flags = []
+c_paths = []
+c_compile_flags = []
+[build-native]
+cpp_paths = ["native/main.cpp"]
+cpp_compile_flags = []
+cpp_link_flags = []
+c_paths = []
+c_compile_flags = []

--- a/test/canisters/canister_user_timer_override/native/main.cpp
+++ b/test/canisters/canister_user_timer_override/native/main.cpp
@@ -1,0 +1,108 @@
+// Native test driver for the canister_user_timer_override smoke canister.
+//
+// Proves that a user-supplied strong canister_global_timer overrides the
+// icpp-pro built-in weak dispatcher. The test:
+//   1. Registers a recurring IcTimers timer (bumps g_icpp_callback_calls
+//      if the icpp-pro dispatcher ever runs).
+//   2. Drives canister_global_timer once via MockIC.
+//   3. Asserts the user's counter advanced AND the icpp-pro callback
+//      counter stayed at 0 AND the icpp-pro timer registry size stayed at
+//      1 (the recurring timer was not drained).
+
+#include "main.h"
+
+#include <iostream>
+
+#include "ic_api.h"
+#include "ic_timers.h"
+#include "icpp_hooks.h"
+#include "mock_ic.h"
+
+#include "../src/my_canister.h"
+
+namespace {
+
+constexpr const char *EMPTY_CANDID = "4449444c0000";
+
+// Candid for `(period_ns: nat64)` with period = 1_000_000_000 ns (1 s).
+// 4449444c -> "DIDL" magic, 00 -> 0 type-table entries, 01 -> 1 arg, 78 ->
+// nat64 type, then 8 bytes little-endian = 1_000_000_000.
+constexpr const char *CANDID_NAT64_1S = "4449444c00017800ca9a3b00000000";
+
+int expect_eq_u64(const char *label, uint64_t actual, uint64_t expected) {
+  if (actual != expected) {
+    std::cout << "FAIL: " << label << " expected " << expected << ", got "
+              << actual << std::endl;
+    return 1;
+  }
+  std::cout << "PASS: " << label << " == " << actual << std::endl;
+  return 0;
+}
+
+} // namespace
+
+int main() {
+  bool exit_on_fail = false;
+  MockIC mockIC(exit_on_fail);
+
+  std::string my_principal{
+      "expmt-gtxsw-inftj-ttabj-qhp5s-nozup-n3bbo-k7zvn-dg4he-knac3-lae"};
+  bool silent_on_trap = true;
+  int extra_failures = 0;
+
+  mockIC.run_test("canister_init", canister_init, EMPTY_CANDID, "",
+                  silent_on_trap, my_principal);
+
+  // Register a recurring IcTimers timer with period 1s. Whether this
+  // callback ever fires depends on whether the icpp-pro built-in dispatcher
+  // runs. Below we drive canister_global_timer manually; if the user's
+  // strong override won at link time, only g_user_dispatcher_calls will
+  // advance, not g_icpp_callback_calls.
+  mockIC.run_test("start_user_timer", start_user_timer, CANDID_NAT64_1S, "",
+                  silent_on_trap, my_principal);
+  extra_failures += expect_eq_u64("registry size after start_user_timer",
+                                  IcTimers::instance().size(), 1);
+  extra_failures += expect_eq_u64("g_user_dispatcher_calls before dispatch",
+                                  g_user_dispatcher_calls, 0);
+  extra_failures += expect_eq_u64("g_icpp_callback_calls before dispatch",
+                                  g_icpp_callback_calls, 0);
+
+  // Drive canister_global_timer. With the override in place, this resolves
+  // to my_canister.cpp::canister_global_timer (strong) — NOT the icpp-pro
+  // weak dispatcher.
+  mockIC.run_test("canister_global_timer (user override)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+
+  // The defining assertions:
+  extra_failures += expect_eq_u64(
+      "g_user_dispatcher_calls after dispatch (user override ran)",
+      g_user_dispatcher_calls, 1);
+  extra_failures += expect_eq_u64(
+      "g_icpp_callback_calls after dispatch (icpp-pro dispatcher did NOT run)",
+      g_icpp_callback_calls, 0);
+  extra_failures += expect_eq_u64(
+      "registry size after dispatch (icpp-pro registry not drained)",
+      IcTimers::instance().size(), 1);
+
+  // Drive again to confirm repeated invocation also resolves to user.
+  mockIC.run_test("canister_global_timer (user override, second call)",
+                  canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
+                  my_principal);
+  extra_failures += expect_eq_u64(
+      "g_user_dispatcher_calls after second dispatch", g_user_dispatcher_calls,
+      2);
+  extra_failures +=
+      expect_eq_u64("g_icpp_callback_calls still 0 after second dispatch",
+                    g_icpp_callback_calls, 0);
+  extra_failures += expect_eq_u64("registry size still 1 after second dispatch",
+                                  IcTimers::instance().size(), 1);
+
+  std::cout << "\n----------\n";
+  std::cout << "Extra direct-state assertions: "
+            << (extra_failures == 0 ? "all PASSED" : "some FAILED")
+            << std::endl;
+
+  int summary_rc = mockIC.test_summary();
+  return summary_rc != 0 ? summary_rc : (extra_failures > 0 ? 1 : 0);
+}

--- a/test/canisters/canister_user_timer_override/native/main.cpp
+++ b/test/canisters/canister_user_timer_override/native/main.cpp
@@ -89,9 +89,9 @@ int main() {
   mockIC.run_test("canister_global_timer (user override, second call)",
                   canister_global_timer, EMPTY_CANDID, "", silent_on_trap,
                   my_principal);
-  extra_failures += expect_eq_u64(
-      "g_user_dispatcher_calls after second dispatch", g_user_dispatcher_calls,
-      2);
+  extra_failures +=
+      expect_eq_u64("g_user_dispatcher_calls after second dispatch",
+                    g_user_dispatcher_calls, 2);
   extra_failures +=
       expect_eq_u64("g_icpp_callback_calls still 0 after second dispatch",
                     g_icpp_callback_calls, 0);

--- a/test/canisters/canister_user_timer_override/native/main.h
+++ b/test/canisters/canister_user_timer_override/native/main.h
@@ -1,0 +1,2 @@
+// Main entry point for a native debug executable.
+// Build it with: `icpp build-native` from the parent folder where 'icpp.toml' resides

--- a/test/canisters/canister_user_timer_override/src/my_canister.cpp
+++ b/test/canisters/canister_user_timer_override/src/my_canister.cpp
@@ -45,8 +45,8 @@ void start_user_timer() {
   IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
   uint64_t period_ns{0};
   ic_api.from_wire(CandidTypeNat64{&period_ns});
-  g_user_timer_id = IC_API::set_timer_recurring(
-      period_ns, []() { ++g_icpp_callback_calls; });
+  g_user_timer_id =
+      IC_API::set_timer_recurring(period_ns, []() { ++g_icpp_callback_calls; });
   ic_api.to_wire(CandidTypeNat64{g_user_timer_id});
 }
 

--- a/test/canisters/canister_user_timer_override/src/my_canister.cpp
+++ b/test/canisters/canister_user_timer_override/src/my_canister.cpp
@@ -1,0 +1,78 @@
+// User-supplied canister_global_timer override.
+//
+// The icpp-pro side defines canister_global_timer with __attribute__((weak))
+// in src/icpp/ic/canister/canister_global_timer_export.cpp. The strong
+// definition below takes precedence at link time. To prove the override
+// actually wins (and the icpp-pro built-in dispatcher does NOT run), the
+// canister also registers a recurring IcTimers timer; if the icpp-pro
+// dispatcher had run, that timer's callback would advance
+// g_icpp_callback_calls. The test asserts user_dispatcher_calls > 0 AND
+// icpp_callback_calls == 0.
+
+#include "my_canister.h"
+
+#include <string>
+
+#include "ic_api.h"
+#include "ic_timers.h"
+
+uint64_t g_user_dispatcher_calls{0};
+uint64_t g_icpp_callback_calls{0};
+
+namespace {
+uint64_t g_user_timer_id{0};
+} // namespace
+
+void canister_init() {
+  IC_API ic_api(CanisterInit{std::string(__func__)}, false);
+}
+
+// The strong override. NO __attribute__((weak)). When linked against
+// icpp-pro's weak definition, wasm-ld picks this one.
+void canister_global_timer() {
+  // The IC's T-entry rules forbid msg_arg/msg_caller here; the IC_API
+  // constructor's T-entry guard skips those reads when the entry token is
+  // CanisterGlobalTimer.
+  IC_API ic_api(CanisterGlobalTimer{std::string(__func__)}, false);
+  ++g_user_dispatcher_calls;
+  // Deliberately do NOT call IcTimers::instance().dispatch_due(...). The
+  // icpp-pro registry stays untouched, which the test verifies by asserting
+  // get_icpp_timer_count() stays at 1 after this fires and
+  // g_icpp_callback_calls stays at 0.
+}
+
+void start_user_timer() {
+  IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
+  uint64_t period_ns{0};
+  ic_api.from_wire(CandidTypeNat64{&period_ns});
+  g_user_timer_id = IC_API::set_timer_recurring(
+      period_ns, []() { ++g_icpp_callback_calls; });
+  ic_api.to_wire(CandidTypeNat64{g_user_timer_id});
+}
+
+void stop_user_timer() {
+  IC_API ic_api(CanisterUpdate{std::string(__func__)}, false);
+  uint64_t id{0};
+  ic_api.from_wire(CandidTypeNat64{&id});
+  bool ok = IC_API::cancel_timer(id);
+  ic_api.to_wire(CandidTypeBool{ok});
+}
+
+void get_user_dispatcher_calls() {
+  IC_API ic_api(CanisterQuery{std::string(__func__)}, false);
+  ic_api.from_wire();
+  ic_api.to_wire(CandidTypeNat64{g_user_dispatcher_calls});
+}
+
+void get_icpp_callback_calls() {
+  IC_API ic_api(CanisterQuery{std::string(__func__)}, false);
+  ic_api.from_wire();
+  ic_api.to_wire(CandidTypeNat64{g_icpp_callback_calls});
+}
+
+void get_icpp_timer_count() {
+  IC_API ic_api(CanisterQuery{std::string(__func__)}, false);
+  ic_api.from_wire();
+  ic_api.to_wire(
+      CandidTypeNat64{static_cast<uint64_t>(IcTimers::instance().size())});
+}

--- a/test/canisters/canister_user_timer_override/src/my_canister.did
+++ b/test/canisters/canister_user_timer_override/src/my_canister.did
@@ -1,0 +1,7 @@
+service : {
+  start_user_timer : (nat64) -> (nat64);
+  stop_user_timer : (nat64) -> (bool);
+  get_user_dispatcher_calls : () -> (nat64) query;
+  get_icpp_callback_calls : () -> (nat64) query;
+  get_icpp_timer_count : () -> (nat64) query;
+}

--- a/test/canisters/canister_user_timer_override/src/my_canister.h
+++ b/test/canisters/canister_user_timer_override/src/my_canister.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+
+#include "wasm_symbol.h"
+
+// Counters and ids exposed for the native test driver to inspect directly.
+// g_user_dispatcher_calls increments inside the user's strong override of
+// canister_global_timer (defined in my_canister.cpp). g_icpp_callback_calls
+// increments inside a recurring timer registered through the icpp-pro
+// IcTimers registry — if the icpp-pro built-in dispatcher had run, the
+// callback would fire and this counter would advance; if the user's strong
+// override won at link time, this counter stays at 0.
+extern uint64_t g_user_dispatcher_calls;
+extern uint64_t g_icpp_callback_calls;
+
+void canister_init() WASM_SYMBOL_EXPORTED("canister_init");
+
+// Strong user-supplied canister_global_timer. The icpp-pro side defines
+// its own version with __attribute__((weak)), so wasm-ld picks this one.
+void canister_global_timer() WASM_SYMBOL_EXPORTED("canister_global_timer");
+
+void start_user_timer()
+    WASM_SYMBOL_EXPORTED("canister_update start_user_timer");
+void stop_user_timer() WASM_SYMBOL_EXPORTED("canister_update stop_user_timer");
+
+void get_user_dispatcher_calls()
+    WASM_SYMBOL_EXPORTED("canister_query get_user_dispatcher_calls");
+void get_icpp_callback_calls()
+    WASM_SYMBOL_EXPORTED("canister_query get_icpp_callback_calls");
+void get_icpp_timer_count()
+    WASM_SYMBOL_EXPORTED("canister_query get_icpp_timer_count");

--- a/test/canisters/canister_user_timer_override/test/conftest.py
+++ b/test/canisters/canister_user_timer_override/test/conftest.py
@@ -4,4 +4,4 @@
 
 # pylint: disable=missing-function-docstring, unused-import, wildcard-import, unused-wildcard-import, line-too-long, unused-argument
 import pytest
-from icpp.conftest_base import *  # pytest fixtures provided by icpp-pro
+from icpp.conftest_base import *  # noqa: F403  # pytest fixtures provided by icpp-pro

--- a/test/canisters/canister_user_timer_override/test/conftest.py
+++ b/test/canisters/canister_user_timer_override/test/conftest.py
@@ -1,0 +1,7 @@
+"""The pytest fixtures
+   https://docs.pytest.org/en/latest/fixture.html
+"""
+
+# pylint: disable=missing-function-docstring, unused-import, wildcard-import, unused-wildcard-import, line-too-long, unused-argument
+import pytest
+from icpp.conftest_base import *  # pytest fixtures provided by icpp-pro

--- a/test/canisters/canister_user_timer_override/test/test_apis.py
+++ b/test/canisters/canister_user_timer_override/test/test_apis.py
@@ -1,0 +1,95 @@
+"""Test that a user-supplied strong canister_global_timer overrides the
+   icpp-pro weak built-in dispatcher end-to-end on a real local replica.
+
+   First deploy the canister, then run:
+
+   $ pytest --network=[local/ic]
+"""
+
+# pylint: disable=missing-function-docstring, unused-import, wildcard-import, unused-wildcard-import
+
+import re
+import time
+from pathlib import Path
+
+import pytest
+
+from icpp.smoketest import call_canister_api
+
+DFX_JSON_PATH = Path(__file__).parent / "../dfx.json"
+CANISTER_NAME = "my_canister"
+
+
+def _parse_nat64(response: str) -> int:
+    m = re.search(r"\(\s*([0-9_]+)\s*:\s*nat64\s*\)", response)
+    if not m:
+        pytest.fail(f"could not parse nat64 from response: {response!r}")
+    return int(m.group(1).replace("_", ""))
+
+
+def test__user_override_wins_on_real_ic(network: str, principal: str) -> None:
+    # Register a 1 s recurring IcTimers timer via the user's update method.
+    # Capture the id so we can cancel it in the finally block — keeps the
+    # suite re-runnable even if an assertion below fails.
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="start_user_timer",
+        canister_argument="(1_000_000_000 : nat64)",
+        network=network,
+    )
+    timer_id = _parse_nat64(response)
+    assert timer_id > 0
+
+    try:
+        # Bounded wait — recurring-timer firings are timing-dependent on a
+        # busy local replica. Sleep ~3 s to let the IC fire
+        # canister_global_timer at least once.
+        time.sleep(3.0)
+
+        # Query the three counters.
+        user_calls = _parse_nat64(
+            call_canister_api(
+                dfx_json_path=DFX_JSON_PATH,
+                canister_name=CANISTER_NAME,
+                canister_method="get_user_dispatcher_calls",
+                network=network,
+            )
+        )
+        icpp_calls = _parse_nat64(
+            call_canister_api(
+                dfx_json_path=DFX_JSON_PATH,
+                canister_name=CANISTER_NAME,
+                canister_method="get_icpp_callback_calls",
+                network=network,
+            )
+        )
+        icpp_timer_count = _parse_nat64(
+            call_canister_api(
+                dfx_json_path=DFX_JSON_PATH,
+                canister_name=CANISTER_NAME,
+                canister_method="get_icpp_timer_count",
+                network=network,
+            )
+        )
+
+        # Range-only assertions — exact recurring-fire counts will flake.
+        assert (
+            user_calls >= 1
+        ), f"user override did not run on the IC (user_calls={user_calls})"
+        assert (
+            icpp_calls == 0
+        ), f"icpp-pro built-in dispatcher fired despite user override (icpp_calls={icpp_calls})"
+        assert (
+            icpp_timer_count >= 1
+        ), f"icpp-pro registry was drained — dispatcher must have run (icpp_timer_count={icpp_timer_count})"
+    finally:
+        # Always cancel via the rev0 IC_API::cancel_timer(id) public API
+        # so the registry is empty and the suite is re-runnable.
+        call_canister_api(
+            dfx_json_path=DFX_JSON_PATH,
+            canister_name=CANISTER_NAME,
+            canister_method="stop_user_timer",
+            canister_argument=f"({timer_id} : nat64)",
+            network=network,
+        )

--- a/test/canisters/canister_user_timer_override/test/test_apis.py
+++ b/test/canisters/canister_user_timer_override/test/test_apis.py
@@ -42,20 +42,26 @@ def test__user_override_wins_on_real_ic(network: str, principal: str) -> None:
     assert timer_id > 0
 
     try:
-        # Bounded wait — recurring-timer firings are timing-dependent on a
-        # busy local replica. Sleep ~3 s to let the IC fire
-        # canister_global_timer at least once.
-        time.sleep(3.0)
-
-        # Query the three counters.
-        user_calls = _parse_nat64(
-            call_canister_api(
-                dfx_json_path=DFX_JSON_PATH,
-                canister_name=CANISTER_NAME,
-                canister_method="get_user_dispatcher_calls",
-                network=network,
+        # Poll until the user override has fired at least once, with a
+        # bounded deadline. This adapts to replica load — fixed sleeps were
+        # both flake-prone on busy boxes (too short) and wasteful on quiet
+        # ones (too long).
+        deadline = time.time() + 15.0
+        user_calls = 0
+        while time.time() < deadline:
+            user_calls = _parse_nat64(
+                call_canister_api(
+                    dfx_json_path=DFX_JSON_PATH,
+                    canister_name=CANISTER_NAME,
+                    canister_method="get_user_dispatcher_calls",
+                    network=network,
+                )
             )
-        )
+            if user_calls >= 1:
+                break
+            time.sleep(0.2)
+
+        # Now query the other two counters to confirm side-effect absence.
         icpp_calls = _parse_nat64(
             call_canister_api(
                 dfx_json_path=DFX_JSON_PATH,


### PR DESCRIPTION
## Summary
- New `IC_API` methods: `set_timer(delay_ns, fn)`, `set_timer_recurring(period_ns, fn)`, `cancel_timer(id)`, plus `global_timer_set_raw(timestamp_ns)` as an escape hatch.
- New `IcTimers` multi-timer scheduler (Motoko-`internals.mo` style): `std::multimap` deadline index + `std::unordered_map` id index, monotonic id counter, 10-per-tick dispatch cap, and Motoko's catch-up formula `next = old + period * (1 + (now - old) / period)` for recurring timers that miss ticks.
- Built-in `canister_global_timer` WASM export shipped in every icpp-pro canister. Mirrors Motoko's enabled-by-default posture; the dispatcher runs cheaply against an empty registry when unused. New `WASM_LDFLAGS` entries (`-Wl,-u,canister_global_timer -Wl,--export=canister_global_timer`) force the export to be linked from the static archive.
- New `ic0.global_timer_set` import in `ic0.h` and matching mock in `ic0mock/ic0.cpp` that records the last armed deadline.
- Bug fix in `IC_API` constructor: skip `msg_arg_data_*` and `msg_caller_*` reads for `T` (timer/heartbeat) entries — those system calls are not allowed in T entries per the IC interface spec and would have trapped on the IC.
- New `test/canisters/canister_timers/` demo: native MockIC driver covering one-shot fire / cancel / unknown-id / 10-per-tick cap, plus a pytest suite that deploys to a local replica and verifies the IC actually fires `canister_global_timer` for one-shot and recurring timers.

Timer state is in-memory only and is not preserved across canister upgrades — same semantics as Motoko. Documented in code comments; users must re-register timers in `canister_post_upgrade` if needed.

## Test plan
- [x] `make python-format` / `python-lint` / `python-type` clean (pylint 10.00/10, mypy strict 0 issues).
- [x] `make cpp-format` clean.
- [x] `make all-canister-native` — all existing test canisters still green; `canister_timers` mockic.exe runs 7 MockIC tests + 14 direct-state assertions, all pass.
- [x] From `test/canisters/canister_timers/`: `icpp build-wasm && dfx start --clean --background && dfx deploy && pytest --network=local` — 3/3 tests pass (`test__one_shot_fires`, `test__recurring_fires_and_can_be_cancelled`, `test__cancel_unknown_returns_false`).
- [x] `strings build/my_canister.wasm | grep -E '^(canister_global_timer|global_timer_set)$'` confirms both the import and the export are present in the produced wasm. Verified the export also appears in pre-existing canisters (e.g. `canister_1`) since the dispatcher is now always-on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-timer scheduler: one-shot & recurring timers, cancellation, and a canister-facing timer dispatch entrypoint; supports user-provided dispatcher overrides and mock-time controls for testing.

* **Bug Fixes**
  * Strip a CLI deprecation banner from captured output to avoid corrupting test parsing.

* **Tests**
  * Added native and integration tests covering timer firing, batching limits, cancellation, overrides, and mock-time scenarios.

* **Chores**
  * Updated Python/CI matrix and tooling versions; improved cleanup utilities and linting configuration; Makefile install targets made more robust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->