### PR TITLE
Fix getenv trap: initialize __wasilibc_environ + add getenv regression tests

### DIFF
--- a/src/icpp/ic/wasi_sdk_traps/__wasilibc_initialize_environ.c
+++ b/src/icpp/ic/wasi_sdk_traps/__wasilibc_initialize_environ.c
@@ -1,4 +1,17 @@
 // Stub all methods of wasi-libc/libc-bottom-half/sources/__wasilibc_initialize_environ.c
+//
+// A canister has no OS environment. Rather than pull in wasi-libc's real
+// environ init (which calls the WASI environ_sizes_get/environ_get imports),
+// we present an EMPTY environment: getenv() etc. must see a valid, empty,
+// NULL-terminated `environ` array and simply return NULL for every name.
+//
+// IMPORTANT (bug fixed 2026-07): the previous version left every function as a
+// no-op, so `__wasilibc_environ` stayed at its (char**)-1 sentinel. getenv()
+// calls __wasilibc_ensure_environ() (a no-op) and then dereferenced -1
+// (address 0xffffffff) -> "heap out of bounds" trap (IC0502) on the very first
+// getenv() call. The `empty_environ` array below was defined for exactly this
+// purpose but was never assigned. The functions now point __wasilibc_environ at
+// it, so getenv() safely returns NULL.
 
 #include <unistd.h>
 #include <stdlib.h>
@@ -13,28 +26,33 @@
 /// `clearenv` sets it to NULL.
 char **__wasilibc_environ __attribute__((weak)) = (char **)-1;
 
-// See the comments in libc-environ.h.
-void __wasilibc_ensure_environ(void) {
-  // Do Nothing
-}
-
 /// Avoid dynamic allocation for the case where there are no environment
 /// variables, but we still need a non-NULL pointer to an (empty) array.
-static char *empty_environ[1] = { NULL };
+static char *empty_environ[1] = {NULL};
 
 // See the comments in libc-environ.h.
-void __wasilibc_initialize_environ(void) {
-  // Do Nothing
+// A canister always has an empty environment, so "initialize" simply points
+// __wasilibc_environ at the empty (NULL-terminated) array.
+void __wasilibc_initialize_environ(void) { __wasilibc_environ = empty_environ; }
+
+// See the comments in libc-environ.h.
+// getenv() and friends call this before touching __wasilibc_environ. Initialize
+// on first use (when still the (char**)-1 sentinel), matching the semantics of
+// the real wasi-libc implementation.
+void __wasilibc_ensure_environ(void) {
+  if (__wasilibc_environ == (char **)-1) {
+    __wasilibc_initialize_environ();
+  }
 }
 
 // See the comments in libc-environ.h.
-void __wasilibc_deinitialize_environ(void) {
-  // Do Nothing
-}
+// Reset to the sentinel so a subsequent __wasilibc_ensure_environ() re-inits.
+void __wasilibc_deinitialize_environ(void) { __wasilibc_environ = (char **)-1; }
 
 // See the comments in libc-environ.h.
-__attribute__((weak))
-void __wasilibc_maybe_reinitialize_environ_eagerly(void) {
-    // This version does nothing. It may be overridden by a version which does
-    // something if `environ` is used.
+// Pulled in (over the weak stub) when the program references `environ`
+// directly rather than via getenv(). Point it at the empty array so those
+// direct accesses are safe too.
+__attribute__((weak)) void __wasilibc_maybe_reinitialize_environ_eagerly(void) {
+  __wasilibc_initialize_environ();
 }

--- a/test/canisters/canister_1/native/main.cpp
+++ b/test/canisters/canister_1/native/main.cpp
@@ -110,6 +110,11 @@ int main() {
   mockIC.run_test("test_ic_api", test_ic_api, "4449444c0000",
                   "4449444c00017c00", silent_on_trap, my_principal);
 
+  // '()' -> '(0)' : getenv() must not trap and returns NULL for unset names.
+  // (Regression guard for ic/wasi_sdk_traps/__wasilibc_initialize_environ.c.)
+  mockIC.run_test("test_getenv", test_getenv, "4449444c0000",
+                  "4449444c00017c00", silent_on_trap, my_principal);
+
   //----------------------------------------------------------------------------------
   // Run all roundtrip tests
 

--- a/test/canisters/canister_1/src/my_canister.cpp
+++ b/test/canisters/canister_1/src/my_canister.cpp
@@ -9,6 +9,7 @@
 #include "compliance_test_prim.h"
 #include "ic_api.h"
 #include "unit_test_candid.h"
+#include "unit_test_getenv.h"
 #include "unit_test_ic_api.h"
 #include "unit_test_vendors.h"
 
@@ -39,6 +40,12 @@ void test_candid() {
 void test_ic_api() {
   IC_API ic_api(CanisterQuery{std::string(__func__)}, false);
   int result = unit_test_ic_api();
+  ic_api.to_wire(CandidTypeInt{result});
+}
+
+void test_getenv() {
+  IC_API ic_api(CanisterQuery{std::string(__func__)}, false);
+  int result = unit_test_getenv();
   ic_api.to_wire(CandidTypeInt{result});
 }
 

--- a/test/canisters/canister_1/src/my_canister.did
+++ b/test/canisters/canister_1/src/my_canister.did
@@ -24,6 +24,7 @@ service: {
     "test_ic_api" : () -> (int) query;
     "test_candid" : () -> (int) query;
     "test_vendors" : () -> (int) query;
+    "test_getenv" : () -> (int) query;
     "roundtrip_bool_true" : (bool) -> (bool) query;
     "roundtrip_bool_false" : (bool) -> (bool) query;
     "roundtrip_nat_101" : (nat) -> (nat) query;

--- a/test/canisters/canister_1/src/my_canister.h
+++ b/test/canisters/canister_1/src/my_canister.h
@@ -12,6 +12,7 @@ void get_canister_info()
 void test_ic_api() WASM_SYMBOL_EXPORTED("canister_query test_ic_api");
 void test_candid() WASM_SYMBOL_EXPORTED("canister_query test_candid");
 void test_vendors() WASM_SYMBOL_EXPORTED("canister_query test_vendors");
+void test_getenv() WASM_SYMBOL_EXPORTED("canister_query test_getenv");
 
 void roundtrip_deprecated_ic_api_constructor() WASM_SYMBOL_EXPORTED(
     "canister_query roundtrip_deprecated_ic_api_constructor");

--- a/test/canisters/canister_1/src/unit_test_getenv.cpp
+++ b/test/canisters/canister_1/src/unit_test_getenv.cpp
@@ -1,0 +1,52 @@
+// Unit tests for getenv()/environ handling in an ICP canister.
+//
+// Regression guard for icpp-pro's
+//   src/icpp/ic/wasi_sdk_traps/__wasilibc_initialize_environ.c
+//
+// A canister has no OS environment, so getenv() must return NULL for every
+// name -- and, crucially, MUST NOT trap. A previous bug left __wasilibc_environ
+// at its (char**)-1 sentinel with no-op ensure/initialize functions, so the
+// FIRST getenv() call dereferenced address 0xffffffff -> "heap out of bounds"
+// (IC0502). This surfaced e.g. in llama.cpp's tty_can_use_colors() during
+// argument parsing.
+//
+// NOTE on coverage: native/MockIC builds do NOT compile ic/wasi_sdk_traps; they
+// use the host libc getenv (which works). So on native this test only verifies
+// the invented, never-set name returns NULL. The REAL regression is caught by
+// the wasm build (test/test_apis.py::test__getenv), where the icpp override is
+// what actually runs -- there, before the fix, this endpoint traps.
+
+#include "unit_test_getenv.h"
+
+#include <cstdlib>
+
+int unit_test_getenv() {
+  int failures = 0;
+
+  // Exercise getenv() on common names too. In a canister (empty environment)
+  // these all return NULL; on the host they may be set. We do NOT assert their
+  // value -- the point is that CALLING getenv() must not trap. Before the fix
+  // each of these faulted on wasm at the very first call.
+  const char *const probe_names[] = {"PATH",     "HOME", "TERM",
+                                     "NO_COLOR", "LANG", "PWD"};
+  for (const char *name : probe_names) {
+    volatile const char *value = getenv(name);
+    (void)value;
+  }
+
+  // This name is never set on the host or in a canister, so getenv() must
+  // return NULL on BOTH native and wasm.
+  const char *const kUnset = "ICPP_DEFINITELY_UNSET_ENVIRONMENT_VARIABLE_9Z7Q";
+  if (getenv(kUnset) != nullptr) {
+    failures += 1;
+  }
+
+  // Repeated calls must stay stable (no crash, still NULL).
+  for (int i = 0; i < 3; ++i) {
+    if (getenv(kUnset) != nullptr) {
+      failures += 1;
+    }
+  }
+
+  return failures;
+}

--- a/test/canisters/canister_1/src/unit_test_getenv.cpp
+++ b/test/canisters/canister_1/src/unit_test_getenv.cpp
@@ -35,8 +35,12 @@ int unit_test_getenv() {
   }
 
   // This name is never set on the host or in a canister, so getenv() must
-  // return NULL on BOTH native and wasm.
+  // return NULL on BOTH native and wasm. Explicitly unset it first so the
+  // assertion is deterministic on native (where getenv reads the real host
+  // environment) regardless of the developer's shell -- and, as a bonus, this
+  // exercises unsetenv() against the (fixed) empty environ on wasm.
   const char *const kUnset = "ICPP_DEFINITELY_UNSET_ENVIRONMENT_VARIABLE_9Z7Q";
+  unsetenv(kUnset);
   if (getenv(kUnset) != nullptr) {
     failures += 1;
   }

--- a/test/canisters/canister_1/src/unit_test_getenv.h
+++ b/test/canisters/canister_1/src/unit_test_getenv.h
@@ -1,0 +1,3 @@
+// Unit tests for getenv()/environ handling in a canister.
+// Regression guard for ic/wasi_sdk_traps/__wasilibc_initialize_environ.c.
+int unit_test_getenv();

--- a/test/canisters/canister_1/test/test_apis.py
+++ b/test/canisters/canister_1/test/test_apis.py
@@ -88,6 +88,21 @@ def test__test_ic_api(network: str, principal: str) -> None:
     assert response == expected_response
 
 
+def test__test_getenv(network: str, principal: str) -> None:
+    # Regression guard: getenv() in a canister must return NULL for unset names
+    # WITHOUT trapping. Before the ic/wasi_sdk_traps/__wasilibc_initialize_environ.c
+    # fix, calling getenv() dereferenced the (char**)-1 sentinel and trapped with
+    # "heap out of bounds" (IC0502), so this call would fail instead of returning 0.
+    response = call_canister_api(
+        dfx_json_path=DFX_JSON_PATH,
+        canister_name=CANISTER_NAME,
+        canister_method="test_getenv",
+        network=network,
+    )
+    expected_response = "(0 : int)"
+    assert response == expected_response
+
+
 # ----------------------------------------------------------------------------------
 # Run all roundtrip tests
 def test__roundtrip_deprecated_ic_api_constructor(network: str, principal: str) -> None:


### PR DESCRIPTION
## Problem

In a canister wasm build, the **first** call to `getenv()` (or any code touching `environ`) trapped with `heap out of bounds` (IC0502) — a memory fault at wasm address `0xffffffff`.

Root cause was in `src/icpp/ic/wasi_sdk_traps/__wasilibc_initialize_environ.c`: the stubbed `__wasilibc_ensure_environ()` and `__wasilibc_initialize_environ()` were **no-ops**, so `__wasilibc_environ` stayed at its `(char**)-1` sentinel. `getenv()` calls `__wasilibc_ensure_environ()` and then dereferences `__wasilibc_environ` — dereferencing `-1` (`0xffffffff`) faults. The `empty_environ` array was already defined in the file for exactly this purpose but was never assigned.

This surfaced downstream in `llama_cpp_canister` (e.g. llama.cpp's `tty_can_use_colors()` during argument parsing), where it had to be worked around per-project.

## Fix

`__wasilibc_ensure_environ()` / `__wasilibc_initialize_environ()` now point `__wasilibc_environ` at the empty, NULL-terminated `empty_environ` array (matching wasi-libc semantics), so `getenv()` safely returns `NULL` for every name in a canister's empty environment. `deinitialize` / `maybe_reinitialize_eagerly` are made consistent. A dated header comment documents the bug.

## Regression tests (native + wasm)

Added to `test/canisters/canister_1`:

- `src/unit_test_getenv.{h,cpp}` — probes common env names (crash-probe) and asserts an invented, never-set name returns `NULL`, repeated for stability.
- `src/my_canister.{h,cpp,did}` — new `test_getenv : () -> (int) query` endpoint.
- `native/main.cpp` — MockIC `run_test`.
- `test/test_apis.py` — `test__test_getenv` asserting `(0 : int)` against a real replica (this is the check that actually traps pre-fix).

## Verification

- `make all-tests` (static + native MockIC + deploy-local-pytest across all canisters): all pass.
- Reverting the fix and running the wasm under a faithful wasmtime harness reproduces the exact original fault (`getenv → memory fault at wasm address 0xffffffff`); restoring the fix returns cleanly. Confirms the new test has teeth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `getenv()` in canisters to return `NULL` for unset variables without trapping.
  * Stabilized environment access so repeated calls and reinitialization don’t cause faults.

* **Tests**
  * Added regression coverage to verify `getenv()` remains non-trapping and returns the expected `NULL`/`0` behavior.
  * Added an end-to-end test that exercises a new canister query used for environment-access validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->