### PR TITLE
Build, deploy & test canisters concurrently

### DIFF
--- a/.github/workflows/cicd-mac.yml
+++ b/.github/workflows/cicd-mac.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "src/**"
       - "test/**"
+      # scripts/ drives this very workflow (build/deploy/pytest
+      # orchestration), so changes there must re-run the matrix
+      - "scripts/**"
       - "Makefile"
       - ".github/trigger.txt"
       - ".github/workflows/cicd-mac.yml"

--- a/.github/workflows/cicd-ubuntu.yml
+++ b/.github/workflows/cicd-ubuntu.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "src/**"
       - "test/**"
+      # scripts/ drives this very workflow (build/deploy/pytest
+      # orchestration), so changes there must re-run the matrix
+      - "scripts/**"
       - "Makefile"
       - ".github/trigger.txt"
       - ".github/workflows/cicd-ubuntu.yml"

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,13 @@ summary:
 all-tests: all-static all-canister-native all-canister-deploy-local-pytest 
 	
 .PHONY: all-canister-deploy-local-pytest
+# JOBS = how many canisters to build & test concurrently. Each canister has its
+# own local network on an ephemeral port, so they do not collide. The default is
+# cpu_count/4 (CI runners have 3-4 vCPU -> 1 job, i.e. serial), because
+# icpp build-wasm is itself multi-threaded. Use JOBS=1 to force serial.
+JOBS ?=
 all-canister-deploy-local-pytest: icp-identity-default
-	@python -m scripts.all_canister_deploy_local_pytest
+	@python -m scripts.all_canister_deploy_local_pytest $(if $(JOBS),--jobs $(JOBS),)
 
 # The tests deploy as - and assert on - the `default` identity. Unlike dfx,
 # icp-cli does not create one for you, so create it if it is not there yet.

--- a/scripts/all_canister_deploy_local_pytest.py
+++ b/scripts/all_canister_deploy_local_pytest.py
@@ -1,98 +1,237 @@
-"""Deploys & tests all canisters in a freshly started local network"""
+"""Deploys & tests all canisters, each in its own local network.
 
-import sys
+icp-cli runs a local network per project, and every canister's `icp.yaml` asks
+for an ephemeral gateway port (`gateway.port: 0`), so the canisters do not
+collide and can be built, deployed and tested concurrently. Under dfx this was
+impossible: there was a single global replica on a fixed port.
+
+The default number of jobs is deliberately conservative - `icpp build-wasm` is
+itself multi-threaded, so each canister already uses the available cores. On a
+CI runner (3-4 vCPU) this resolves to 1 job, i.e. today's serial behaviour; on
+a developer machine with many cores it runs several canisters at once. Override
+with `--jobs N`.
+"""
+
+import argparse
+import os
 import shutil
-from pathlib import Path
 import subprocess
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import List, Tuple
+
 import typer
 from icpp.run_shell_cmd import run_shell_cmd
-from icpp.run_icp_cmd import run_icp_cmd
 
 SCRIPTS_PATH = Path(__file__).parent
 ROOT_PATH = Path(__file__).parent.parent
+
+# Generous ceiling: a cold `icpp build-wasm` compiles the whole C++ tree.
+# It matters that this is explicit - `run_shell_cmd` defaults to 30s whenever
+# output is captured, which a build blows through.
+TIMEOUT_SECONDS = 3600
+
+
+class StepError(Exception):
+    """A step of a canister's pipeline failed."""
+
+
+# Canister logs are buffered & printed as one block, so concurrent runs stay
+# readable. That means the only live progress signal is these one-line
+# notices - keep them serialised so they do not interleave mid-line.
+PRINT_LOCK = threading.Lock()
+
+
+def notify(msg: str) -> None:
+    """Prints a single progress line, without interleaving across threads."""
+    with PRINT_LOCK:
+        typer.echo(msg)
+
+
+def default_jobs(n_canisters: int) -> int:
+    """How many canisters to run concurrently, by default.
+
+    `icpp build-wasm` already parallelises across compile units, so running one
+    canister per core would oversubscribe. A quarter of the cores keeps CI
+    (3-4 vCPU -> 1 job, unchanged behaviour) safe while still giving a
+    developer machine real concurrency.
+    """
+    return max(1, min(n_canisters, (os.cpu_count() or 1) // 4))
+
+
+def run_step(cmd: str, cwd: Path, log: List[str]) -> None:
+    """Runs one command, appending its output to `log`. Raises on failure.
+
+    Output is captured rather than streamed, so that concurrent canisters do
+    not interleave their logs into an unreadable mess.
+    """
+    log.append(f"$ {cmd}")
+    try:
+        out = run_shell_cmd(
+            cmd, capture_output=True, cwd=cwd, timeout_seconds=TIMEOUT_SECONDS
+        )
+    except subprocess.CalledProcessError as e:
+        log.append(e.output or "")
+        raise StepError(cmd) from e
+
+    log.append(out)
+    # A timeout does NOT raise - run_shell_cmd returns this marker string
+    # instead, which would otherwise read as success.
+    if out.startswith("ERROR: Command") and "timed out" in out:
+        raise StepError(cmd)
 
 
 def network_stop(canister_path: Path) -> None:
     """Stops the canister's project-local network, if it is running.
 
     `icp network stop` exits non-zero when no network is running, which is not
-    an error for us - we only want the network to be down afterwards.
+    an error for us - we only want the network down afterwards.
     """
     try:
-        run_shell_cmd("icp network stop", capture_output=True, cwd=canister_path)
+        run_shell_cmd(
+            "icp network stop",
+            capture_output=True,
+            cwd=canister_path,
+            timeout_seconds=TIMEOUT_SECONDS,
+        )
     except subprocess.CalledProcessError:
         pass
 
 
-def network_start_clean(canister_path: Path) -> None:
+def network_start_clean(canister_path: Path, log: List[str]) -> None:
     """Starts a clean, project-local network for the canister.
 
     icp-cli has no `--clean` flag. A managed network keeps both its replica
     state and its canister id mappings under `.icp/cache`, so removing that
     directory is the equivalent of `dfx start --clean`.
+
+    NOTE: only `.icp/cache` - never `.icp`, which also holds `data/mappings/`
+    with the mainnet canister ids.
     """
     network_stop(canister_path)
     shutil.rmtree(canister_path / ".icp" / "cache", ignore_errors=True)
-    run_icp_cmd("network start --background", cwd=canister_path)
+    run_step("icp network start --background", canister_path, log)
+
+
+def test_canister(canister_path: Path) -> Tuple[str, bool, List[str]]:
+    """Builds, deploys & tests one canister. Returns (name, ok, log)."""
+    name = canister_path.name
+    notify(f">>>> {name}: started")
+    log: List[str] = [f"==== {name}"]
+    test_api_path = canister_path / "test/test_apis.py"
+    configs = [file.name for file in canister_path.glob("*.toml")]
+
+    try:
+        for config in configs:
+            log.append(f"-- start a clean local network ({name})")
+            network_start_clean(canister_path, log)
+
+            log.append(f"-- build the wasm with config {config}")
+            run_step(
+                f"icpp build-wasm --config {config} --to-compile all",
+                canister_path,
+                log,
+            )
+
+            log.append(f"-- deploy {name}")
+            run_step("icp deploy --environment local --yes", canister_path, log)
+
+            # pytest runs from the canister directory: that is the icp project
+            # root, which is how icp finds icp.yaml and this canister's network.
+            log.append(f"-- pytest {test_api_path}")
+            run_step(f"pytest -vv --network=local {test_api_path}", canister_path, log)
+
+            network_stop(canister_path)
+
+            # For the greet canister, also exercise build-library & --config
+            if name == "greet":
+                log.append(f"-- start a clean local network ({name}, libraries)")
+                network_start_clean(canister_path, log)
+
+                log.append(f"-- build all libraries with config {config}")
+                run_step(f"icpp build-library --config {config}", canister_path, log)
+
+                log.append(f"-- build libhello with config {config}")
+                run_step(
+                    f"icpp build-library --config {config} libhello",
+                    canister_path,
+                    log,
+                )
+
+                log.append(f"-- build the wasm with config {config} (mine-no-lib)")
+                run_step(
+                    f"icpp build-wasm --config {config} --to-compile mine-no-lib",
+                    canister_path,
+                    log,
+                )
+
+                log.append(f"-- deploy {name}")
+                run_step("icp deploy --environment local --yes", canister_path, log)
+
+                log.append(f"-- pytest {test_api_path}")
+                run_step(
+                    f"pytest -vv --network=local {test_api_path}", canister_path, log
+                )
+
+                network_stop(canister_path)
+        return name, True, log
+
+    except StepError as e:
+        log.append(f"!! FAILED: {e}")
+        return name, False, log
+    finally:
+        # Never leave a replica running, whatever happened above.
+        network_stop(canister_path)
 
 
 def main() -> int:
-    """Start local network; Deploy canister; Pytest"""
-    canister_paths_1 = list((ROOT_PATH / "test/canisters").glob("canister_*"))
-    canister_paths_2 = list((ROOT_PATH / "src/icpp/canisters").glob("*"))
-    canister_paths = canister_paths_2 + canister_paths_1
-    for canister_path in canister_paths:
-        typer.echo(f"====\nTesting canister: {canister_path.name}")
+    """Build, deploy & pytest every canister."""
+    canister_paths = sorted(
+        p
+        for p in list((ROOT_PATH / "src/icpp/canisters").glob("*"))
+        + list((ROOT_PATH / "test/canisters").glob("canister_*"))
+        if (p / "icp.yaml").exists()  # skips __pycache__ & friends
+    )
 
-        test_api_path = canister_path / "test/test_apis.py"
-        configs = [file.name for file in canister_path.glob("*.toml")]
-        for config in configs:
-            try:
-                # On Mac & Ubuntu, it is much more flexible, and we test more variations
-                typer.echo("--\nStart a clean local network")
-                network_start_clean(canister_path)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=default_jobs(len(canister_paths)),
+        help="how many canisters to build & test concurrently (1 = serial)",
+    )
+    args = parser.parse_args()
+    jobs = max(1, args.jobs)
 
-                typer.echo(f"--\nBuild the wasm with config {config}")
-                run_shell_cmd(f"icpp build-wasm --config {config} --to-compile all", cwd=canister_path)
+    typer.echo(
+        f"Testing {len(canister_paths)} canisters with {jobs} job(s) "
+        f"on {os.cpu_count()} core(s): "
+        f"{', '.join(p.name for p in canister_paths)}"
+    )
 
-                typer.echo(f"--\nDeploy {canister_path.name}")
-                run_icp_cmd("deploy --environment local --yes", cwd=canister_path)
+    failed: List[str] = []
+    done = 0
+    with ThreadPoolExecutor(max_workers=jobs) as pool:
+        futures = [pool.submit(test_canister, p) for p in canister_paths]
+        # as_completed, not map: report each canister the moment IT finishes,
+        # rather than waiting for the ones submitted before it.
+        for future in as_completed(futures):
+            name, ok, log = future.result()
+            done += 1
+            with PRINT_LOCK:
+                typer.echo("\n".join(log))
+                typer.echo(
+                    f"---- {name}: {'PASSED' if ok else 'FAILED'} "
+                    f"({done}/{len(canister_paths)})\n"
+                )
+            if not ok:
+                failed.append(name)
 
-                typer.echo(f"--\nRun pytest on {test_api_path}")
-                # Run from the canister directory: that is the icp project root,
-                # which is how icp-cli finds icp.yaml and the local network.
-                run_shell_cmd(f"pytest -vv --network=local {test_api_path}", cwd=canister_path)
-
-                typer.echo("--\nStop the local network")
-                network_stop(canister_path)
-
-                # For greet canister, also test build-library & --config flags
-                if canister_path.name == "greet":
-                    typer.echo("--\nStart a clean local network")
-                    network_start_clean(canister_path)
-
-                    typer.echo(f"--\nBuild all libraries for the greet canister with config {config}")
-                    run_shell_cmd(f"icpp build-library --config {config} ", cwd=canister_path)
-
-                    typer.echo(f"--\nBuild libhello for the greet canister with config {config}")
-                    run_shell_cmd(f"icpp build-library --config {config} libhello", cwd=canister_path)
-
-                    typer.echo(f"--\nBuild the wasm with config {config}")
-                    run_shell_cmd(f"icpp build-wasm --config {config} --to-compile mine-no-lib", cwd=canister_path)
-
-                    typer.echo(f"--\nDeploy {canister_path.name}")
-                    run_icp_cmd("deploy --environment local --yes", cwd=canister_path)
-
-                    typer.echo(f"--\nRun pytest on {test_api_path}")
-                    run_shell_cmd(f"pytest -vv --network=local {test_api_path}", cwd=canister_path)
-
-                    typer.echo("--\nStop the local network")
-                    network_stop(canister_path)
-
-            except subprocess.CalledProcessError as e:
-                typer.echo("--\nSomething did not pass")
-                network_stop(canister_path)
-                return e.returncode
+    if failed:
+        typer.echo(f"--\nSomething did not pass: {', '.join(failed)}")
+        return 1
 
     typer.echo("--\nCongratulations, everything passed!")
     try:

--- a/scripts/all_canister_deploy_local_pytest.py
+++ b/scripts/all_canister_deploy_local_pytest.py
@@ -61,13 +61,26 @@ def default_jobs(n_canisters: int) -> int:
     return max(1, min(n_canisters, (os.cpu_count() or 1) // 4))
 
 
-def run_step(cmd: str, cwd: Path, log: List[str]) -> None:
+def run_step(cmd: str, cwd: Path, log: List[str], stream: bool = False) -> None:
     """Runs one command, appending its output to `log`. Raises on failure.
 
-    Output is captured rather than streamed, so that concurrent canisters do
-    not interleave their logs into an unreadable mess.
+    With `stream=True` the output goes straight to the terminal as it is
+    produced, which is what you want when only one canister is running: CI
+    logs stay live (so a hang shows where it stalled) and an interactive
+    `--jobs 1` debug session behaves as it always has.
+
+    With `stream=False` the output is captured and returned via `log`, so that
+    concurrent canisters do not interleave into an unreadable mess.
     """
     log.append(f"$ {cmd}")
+    if stream:
+        # No capture => no timeout => output goes straight to the terminal.
+        try:
+            run_shell_cmd(cmd, cwd=cwd)
+        except subprocess.CalledProcessError as e:
+            raise StepError(cmd) from e
+        return
+
     try:
         out = run_shell_cmd(
             cmd, capture_output=True, cwd=cwd, timeout_seconds=TIMEOUT_SECONDS
@@ -100,7 +113,7 @@ def network_stop(canister_path: Path) -> None:
         pass
 
 
-def network_start_clean(canister_path: Path, log: List[str]) -> None:
+def network_start_clean(canister_path: Path, log: List[str], stream: bool) -> None:
     """Starts a clean, project-local network for the canister.
 
     icp-cli has no `--clean` flag. A managed network keeps both its replica
@@ -112,10 +125,12 @@ def network_start_clean(canister_path: Path, log: List[str]) -> None:
     """
     network_stop(canister_path)
     shutil.rmtree(canister_path / ".icp" / "cache", ignore_errors=True)
-    run_step("icp network start --background", canister_path, log)
+    run_step("icp network start --background", canister_path, log, stream)
 
 
-def test_canister(canister_path: Path) -> Tuple[str, bool, List[str]]:
+def test_canister(
+    canister_path: Path, stream: bool = False
+) -> Tuple[str, bool, List[str]]:
     """Builds, deploys & tests one canister. Returns (name, ok, log)."""
     name = canister_path.name
     notify(f">>>> {name}: started")
@@ -126,38 +141,47 @@ def test_canister(canister_path: Path) -> Tuple[str, bool, List[str]]:
     try:
         for config in configs:
             log.append(f"-- start a clean local network ({name})")
-            network_start_clean(canister_path, log)
+            network_start_clean(canister_path, log, stream)
 
             log.append(f"-- build the wasm with config {config}")
             run_step(
                 f"icpp build-wasm --config {config} --to-compile all",
                 canister_path,
                 log,
+                stream,
             )
 
             log.append(f"-- deploy {name}")
-            run_step("icp deploy --environment local --yes", canister_path, log)
+            run_step("icp deploy --environment local --yes", canister_path, log, stream)
 
             # pytest runs from the canister directory: that is the icp project
             # root, which is how icp finds icp.yaml and this canister's network.
             log.append(f"-- pytest {test_api_path}")
-            run_step(f"pytest -vv --network=local {test_api_path}", canister_path, log)
+            run_step(
+                f"pytest -vv --network=local {test_api_path}",
+                canister_path,
+                log,
+                stream,
+            )
 
             network_stop(canister_path)
 
             # For the greet canister, also exercise build-library & --config
             if name == "greet":
                 log.append(f"-- start a clean local network ({name}, libraries)")
-                network_start_clean(canister_path, log)
+                network_start_clean(canister_path, log, stream)
 
                 log.append(f"-- build all libraries with config {config}")
-                run_step(f"icpp build-library --config {config}", canister_path, log)
+                run_step(
+                    f"icpp build-library --config {config}", canister_path, log, stream
+                )
 
                 log.append(f"-- build libhello with config {config}")
                 run_step(
                     f"icpp build-library --config {config} libhello",
                     canister_path,
                     log,
+                    stream,
                 )
 
                 log.append(f"-- build the wasm with config {config} (mine-no-lib)")
@@ -165,14 +189,20 @@ def test_canister(canister_path: Path) -> Tuple[str, bool, List[str]]:
                     f"icpp build-wasm --config {config} --to-compile mine-no-lib",
                     canister_path,
                     log,
+                    stream,
                 )
 
                 log.append(f"-- deploy {name}")
-                run_step("icp deploy --environment local --yes", canister_path, log)
+                run_step(
+                    "icp deploy --environment local --yes", canister_path, log, stream
+                )
 
                 log.append(f"-- pytest {test_api_path}")
                 run_step(
-                    f"pytest -vv --network=local {test_api_path}", canister_path, log
+                    f"pytest -vv --network=local {test_api_path}",
+                    canister_path,
+                    log,
+                    stream,
                 )
 
                 network_stop(canister_path)
@@ -214,7 +244,10 @@ def main() -> int:
     failed: List[str] = []
     done = 0
     with ThreadPoolExecutor(max_workers=jobs) as pool:
-        futures = [pool.submit(test_canister, p) for p in canister_paths]
+        # Stream output when there is no concurrency to garble it: keeps CI
+        # logs live and `--jobs 1` debugging exactly as it was before.
+        stream = jobs == 1
+        futures = [pool.submit(test_canister, p, stream) for p in canister_paths]
         # as_completed, not map: report each canister the moment IT finishes,
         # rather than waiting for the ones submitted before it.
         for future in as_completed(futures):


### PR DESCRIPTION
Each canister's `icp.yaml` asks for an ephemeral gateway port (`gateway.port: 0`), so their
local networks no longer collide and can run at the same time. This was impossible under
dfx, which had a single global replica on a fixed port.

`scripts/all_canister_deploy_local_pytest.py` now builds, deploys and tests the canisters
concurrently.

## Measured

| | wall clock | result |
| --- | --- | --- |
| serial (`JOBS=1`)      | 790s (13m10s) | 7/7 passed |
| parallel (default, 4 jobs) | 515s (8m35s) | 7/7 passed |

**1.53x**, not 4x, because `icpp build-wasm` is itself multi-threaded - four concurrent
builds mostly contend for cores they were already using. Still ~4.5 minutes off every local
run.

## CI behaviour is unchanged

The default is deliberately conservative:

```python
max(1, min(n_canisters, (os.cpu_count() or 1) // 4))
```

| environment | cores | jobs |
| --- | --- | --- |
| developer machine | 16 | 4 |
| ubuntu-latest | 4 | **1** |
| macos-latest (arm) | 3 | **1** |
| macos-15-intel | 4 | **1** |

Every CI runner resolves to 1 job, i.e. exactly today's serial behaviour. Running 7
canisters at once on a 3-core / 7 GB runner would thrash, so this is not something to opt
into on CI without measuring there first. Override anywhere with
`make all-canister-deploy-local-pytest JOBS=N`.

## Output

- **`jobs == 1` streams live**, exactly as before this PR. That matters: with buffered
  output a hung CI job would show *nothing* until the step timed out, instead of showing
  where it stalled. Buffering only buys something when there is concurrency to garble, so
  it is only used when `jobs > 1`.
- **`jobs > 1`** captures per canister and prints one block per canister, so concurrent
  logs do not interleave. Progress is reported via `>>>> name: started` /
  `---- name: PASSED (3/7)` lines, serialised behind a lock.
- Completed canisters are reported via `as_completed`, so a fast canister is not held
  behind a slow one submitted before it.

## Incidental fixes

- `canisters` glob treated `__pycache__` as a canister; it now selects only directories
  containing an `icp.yaml`.
- A failing run now reports **every** failing canister, instead of returning on the first.
- Each canister stops its network in a `finally`, so a failure cannot leave replicas
  running and holding ports.
- `run_shell_cmd` defaults to a **30s timeout when output is captured**, and on timeout
  **returns an error string rather than raising** - which would read as a pass. The runner
  sets an explicit timeout and checks for that marker.
- `scripts/` is not in the Makefile's `PYTHON_DIRS`, so this file was previously unlinted
  and had line-too-long violations. It is now clean under `pylint` and `mypy --strict`.

## Verification

Both modes run green end to end: `JOBS=1` 7/7, parallel 7/7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local deployment and pytest checks can now run multiple canisters concurrently.
  * Added an optional jobs setting to control the number of parallel canister tasks.
  * Added configurable command timeouts and clearer progress reporting.

* **Bug Fixes**
  * Improved cleanup and network handling after canister checks.
  * All canister failures are now reported together, with an appropriate failure result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->