### PR TITLE
Drop support for Python 3.10

### DIFF
--- a/.github/workflows/cicd-mac.yml
+++ b/.github/workflows/cicd-mac.yml
@@ -23,9 +23,11 @@ jobs:
       # on its own and is rerun-able independently from the GitHub UI.
       fail-fast: false
       matrix:
-        # NOTE: Python versions MUST be quoted strings — unquoted 3.10 is
-        # parsed by YAML as the float 3.1 and breaks actions/setup-python.
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # NOTE: Python versions MUST be quoted strings — YAML parses an
+        # unquoted x.y0 (e.g. 3.10, 3.20) as a float, which would break
+        # actions/setup-python. Keep the quotes even though the current
+        # matrix has no such version.
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         # macos-15-intel for Intel, macos-latest for Apple Silicon arm64
         os: [macos-15-intel, macos-latest]
 

--- a/.github/workflows/cicd-ubuntu.yml
+++ b/.github/workflows/cicd-ubuntu.yml
@@ -21,9 +21,11 @@ jobs:
       # in cicd-mac.yml. Each cell stands or falls on its own.
       fail-fast: false
       matrix:
-        # NOTE: Python versions MUST be quoted strings — unquoted 3.10 is
-        # parsed by YAML as the float 3.1 and breaks actions/setup-python.
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # NOTE: Python versions MUST be quoted strings — YAML parses an
+        # unquoted x.y0 (e.g. 3.10, 3.20) as a float, which would break
+        # actions/setup-python. Keep the quotes even though the current
+        # matrix has no such version.
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cicd-wheel-test.yml
+++ b/.github/workflows/cicd-wheel-test.yml
@@ -36,13 +36,13 @@ jobs:
           path: icpp-candid
           fetch-depth: 0
 
-      # Use the minimum supported Python (matches `requires-python = ">=3.10"`
+      # Use the minimum supported Python (matches `requires-python = ">=3.11"`
       # in pyproject.toml). Packaging bugs are version-independent, so one
       # cell is sufficient.
       - name: set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: install build tooling
         run: python -m pip install --upgrade pip build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 name = "icpp-pro"
 description = "C++ Canister Development Kit (CDK) for the Internet Computer"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [{ name = "icpp-pro", email = "icpp@icpp.world" }]
 maintainers = [{ name = "icpp-pro", email = "icpp@icpp.world" }]
 license = { file = "LICENSE" }
@@ -37,7 +37,6 @@ classifiers = [
     # that you indicate you support Python 3. These classifiers are *not*
     # checked by 'pip install'. See instead 'python_requires' below.
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
Closes #46.

Python 3.10 reaches end of life in October 2026. It was the oldest version supported and the
only reason `requires-python` was still `>=3.10`.

## Changes

**icpp-pro**
- `pyproject.toml`: `requires-python = ">=3.11"`, dropped the 3.10 classifier
- `cicd-mac.yml` / `cicd-ubuntu.yml`: matrix is now `["3.11", "3.12", "3.13", "3.14"]`
- `cicd-wheel-test.yml`: pins 3.11 (it deliberately uses the *minimum* supported version)

**icpp-candid** (already pushed to its `main` as `f43e5ef`, since icpp-pro's wheel-test
builds it from there)
- Its metadata was stale in two ways the issue did not anticipate:
  - `requires-python` was `>=3.9` - *looser* than icpp-pro's `>=3.10`, so a 3.9 user could
    install the library but not the CDK. Now `>=3.11`, matching.
  - Classifiers stopped at 3.12, despite CI testing 3.13 and 3.14. Now 3.11-3.14.

**icpp-docs** (separate repo, uncommitted here)
- `installation.md`: "requires python 3.10 or higher" -> 3.11

## Verified

Built both wheels and checked the metadata is what actually ships:

```
Requires-Python: >=3.11
Classifier: Programming Language :: Python :: 3.11 .. 3.14
```

Then tested that pip *enforces* it, in both directions:

| environment | result |
| --- | --- |
| clean Python **3.10** | `ERROR: Package 'icpp-pro' requires a different Python: 3.10.18 not in '>=3.11'` |
| clean Python **3.11** | installs, `icpp --version` -> 5.5.1 |

`pylint 10.00/10`, `mypy --strict` clean, all three workflow files parse.

## Notes

- **CI drops from 15 matrix jobs to 12** (mac 10 -> 8, ubuntu 5 -> 4), which should ease the
  runner queueing that has been the main source of CI wall-clock.
- The "quote your Python versions" comment referenced 3.10 as its example. Kept the warning
  (it applies to any `x.y0`), but reworded so it no longer points at a version we do not test.
- **This is metadata only - it reaches users on the next release.** Following the precedent of
  4.3.0 ("Remove support for Python 3.8"), that should be a MINOR bump: **5.6.0**. No version
  bump in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported Python versions to 3.11–3.14.
  * Python 3.10 is no longer supported.
  * Updated automated testing and package validation to use Python 3.11 as the minimum runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->