### PR TITLE
Never use the machine-wide active identity in the test framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,15 @@ Tests run in two modes:
 
 Pytest fixtures from `conftest_base.py` provide: `network`, `identity`, `principal`, `identity_anonymous`, `identity_default`. Test conftest files import these with `from icpp.conftest_base import *`.
 
+**Tests must be told which identity to run as** — `pytest --identity <name>` or
+`export ICPP_PRO_TEST_IDENTITY=<name>`; there is no fallback. The name is passed to every
+icp command as `--identity`. icpp-pro never reads or writes the machine-wide active identity
+(`icp identity default`), because it is shared with every other process on the machine: using
+it would clobber the identity you use for mainnet work, and leave a run exposed to anything
+that changes it mid-flight. Deploy with the same identity the tests run as, so that the caller
+of a test is the canister's controller. This repo uses `icpp-pro-testing`, created by the
+Makefile.
+
 ## Version Management
 
-Version is single-sourced in `src/icpp/version.py`. Current: 5.3.0. Release scripts modify this file automatically.
+Version is single-sourced in `src/icpp/version.py`. Current: 6.0.0. Release scripts modify this file automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,14 @@ cd test/canisters/canister_1
 icpp build-native
 ./build-native/mockic.exe
 
-# WASM build + deploy + pytest against local network:
+# WASM build + deploy + pytest against local network.
+# Deploy as the same identity the tests run as, so the caller of a test is the
+# canister's controller. `make` creates `icpp-pro-testing` if it is missing.
 cd test/canisters/canister_1
+export ICPP_PRO_TEST_IDENTITY=icpp-pro-testing
 icpp build-wasm
 icp network start --background
-icp deploy --environment local --yes
+icp deploy --environment local --yes --identity $ICPP_PRO_TEST_IDENTITY
 pytest --network=local
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -78,15 +78,21 @@ all-tests: all-static all-canister-native all-canister-deploy-local-pytest
 # cpu_count/4 (CI runners have 3-4 vCPU -> 1 job, i.e. serial), because
 # icpp build-wasm is itself multi-threaded. Use JOBS=1 to force serial.
 JOBS ?=
-all-canister-deploy-local-pytest: icp-identity-default
+all-canister-deploy-local-pytest: icpp-pro-test-identity
 	@python -m scripts.all_canister_deploy_local_pytest $(if $(JOBS),--jobs $(JOBS),)
 
-# The tests deploy as - and assert on - the `default` identity. Unlike dfx,
-# icp-cli does not create one for you, so create it if it is not there yet.
-.PHONY: icp-identity-default
-icp-identity-default:
-	@icp identity list | grep -qw default || icp identity new default --storage plaintext
-	@icp identity default default
+# The identity the canisters are deployed with and the tests run as. It is
+# named explicitly and passed to every icp command as `--identity`; the
+# machine-wide active identity (`icp identity default`) is never read and never
+# changed, so running the tests cannot disturb the identity you use for
+# mainnet work - and nothing another process does to it can disturb a test run.
+ICPP_PRO_TEST_IDENTITY ?= icpp-pro-testing
+export ICPP_PRO_TEST_IDENTITY
+
+.PHONY: icpp-pro-test-identity
+icpp-pro-test-identity:
+	@icp identity list | grep -qw $(ICPP_PRO_TEST_IDENTITY) || \
+	  icp identity new $(ICPP_PRO_TEST_IDENTITY) --storage plaintext
 
 .PHONY: all-canister-native
 all-canister-native:

--- a/Makefile
+++ b/Makefile
@@ -89,10 +89,14 @@ all-canister-deploy-local-pytest: icpp-pro-test-identity
 ICPP_PRO_TEST_IDENTITY ?= icpp-pro-testing
 export ICPP_PRO_TEST_IDENTITY
 
+# `icp identity principal` exits non-zero for an unknown name, which is an
+# exact check. Grepping `icp identity list` is not: its lines carry the
+# principal too, and `grep -w` treats `-` as a word boundary, so a name like
+# `icpp-pro-testing-old` would match `icpp-pro-testing`.
 .PHONY: icpp-pro-test-identity
 icpp-pro-test-identity:
-	@icp identity list | grep -qw $(ICPP_PRO_TEST_IDENTITY) || \
-	  icp identity new $(ICPP_PRO_TEST_IDENTITY) --storage plaintext
+	@icp identity principal --identity "$(ICPP_PRO_TEST_IDENTITY)" >/dev/null 2>&1 || \
+	  icp identity new "$(ICPP_PRO_TEST_IDENTITY)" --storage plaintext
 
 .PHONY: all-canister-native
 all-canister-native:

--- a/README-contributors-guide.md
+++ b/README-contributors-guide.md
@@ -111,13 +111,30 @@ make install-icp
 icp --version
 ```
 
-The test suite deploys as - and asserts on - an identity named `default`.
-Unlike dfx, icp-cli does not create one for you:
+The test suite deploys as - and runs as - an identity named
+`icpp-pro-testing`. `make` creates it for you if it is not there yet:
 
 ```bash
-icp identity new default --storage plaintext
-icp identity default default
+icp identity new icpp-pro-testing --storage plaintext
 ```
+
+It is passed to every icp command as `--identity`, so **nothing switches your
+machine-wide active identity**. Running the tests cannot disturb the identity
+you use for mainnet work, and nothing another process does to that identity can
+disturb a test run.
+
+To run `pytest` by hand, name the identity yourself:
+
+```bash
+pytest -vv --network=local --identity icpp-pro-testing
+
+# or, once per shell:
+export ICPP_PRO_TEST_IDENTITY=icpp-pro-testing
+pytest -vv --network=local
+```
+
+Use `make all-canister-deploy-local-pytest ICPP_PRO_TEST_IDENTITY=<name>` to
+run the whole suite as a different identity.
 
 
 

--- a/README-release-guide.md
+++ b/README-release-guide.md
@@ -100,7 +100,8 @@ icpp --version
 # test: `greet` project
 icpp init
 cd greet
-icp identity default default
+# The demo scripts create & use their own `greet-testing` identity, and never
+# touch your machine-wide active identity. Nothing to set up here.
 
 # Capture the output - see "Verifying the demo scripts" below for why
 sh ./demo.sh       2>&1 | tee /tmp/release-demo.log
@@ -150,12 +151,17 @@ Better than reading logs - run `pytest` yourself and look at its exit code:
 
 ```bash
 # from: release-test/greet
+export ICPP_PRO_TEST_IDENTITY=greet-testing   # created by demo.sh
+
 icp network stop; rm -rf .icp/cache; icp network start --background
-icp deploy --environment local --yes
+icp deploy --environment local --yes --identity $ICPP_PRO_TEST_IDENTITY
 
 pytest --network=local -q; echo "pytest exit code = $?"
 #  -> 10 passed / exit code = 0
 ```
+
+Deploy with the same identity the tests run as - `test__greet_0_auth_ok` asserts
+on the caller's principal.
 
 Note `echo $?` must be its **own** statement. Piping pytest into `tail`/`grep` and
 then echoing `$?` reports the exit code of the *pipe*, not of pytest.
@@ -169,6 +175,10 @@ really talking to the deployed canister:
 icp network stop
 pytest --network=local -q; echo "pytest exit code = $?"
 #  -> "The local network is not up" / "no tests ran" / exit code = 2
+
+# And that a missing identity is refused rather than guessed:
+env -u ICPP_PRO_TEST_IDENTITY pytest --network=local -q
+#  -> "ERROR: no test identity configured." / exit code = 2
 ```
 
 If that still reports passes, the tests are not reaching the canister and the green

--- a/scripts/all_canister_deploy_local_pytest.py
+++ b/scripts/all_canister_deploy_local_pytest.py
@@ -24,9 +24,16 @@ from typing import List, Tuple
 
 import typer
 from icpp.run_shell_cmd import run_shell_cmd
+from icpp.smoketest import IDENTITY_ENV_VAR
 
 SCRIPTS_PATH = Path(__file__).parent
 ROOT_PATH = Path(__file__).parent.parent
+
+# The canisters are deployed with the identity the tests then run as, so that
+# the caller of a test IS the controller. It has to be named explicitly: the
+# machine-wide active identity is shared with every other process, which is
+# free to change it while a run is in flight. The Makefile exports it.
+TEST_IDENTITY = os.environ.get(IDENTITY_ENV_VAR, "")
 
 # Generous ceiling: a cold `icpp build-wasm` compiles the whole C++ tree.
 # It matters that this is explicit - `run_shell_cmd` defaults to 30s whenever
@@ -152,7 +159,12 @@ def test_canister(
             )
 
             log.append(f"-- deploy {name}")
-            run_step("icp deploy --environment local --yes", canister_path, log, stream)
+            run_step(
+                f"icp deploy --environment local --yes --identity {TEST_IDENTITY}",
+                canister_path,
+                log,
+                stream,
+            )
 
             # pytest runs from the canister directory: that is the icp project
             # root, which is how icp finds icp.yaml and this canister's network.
@@ -194,7 +206,10 @@ def test_canister(
 
                 log.append(f"-- deploy {name}")
                 run_step(
-                    "icp deploy --environment local --yes", canister_path, log, stream
+                    f"icp deploy --environment local --yes --identity {TEST_IDENTITY}",
+                    canister_path,
+                    log,
+                    stream,
                 )
 
                 log.append(f"-- pytest {test_api_path}")
@@ -218,6 +233,16 @@ def test_canister(
 
 def main() -> int:
     """Build, deploy & pytest every canister."""
+    if not TEST_IDENTITY:
+        typer.echo(
+            f"ERROR: ${IDENTITY_ENV_VAR} is not set.\n"
+            f"       It names the identity the canisters are deployed with and\n"
+            f"       the tests run as. Run this through the Makefile, which\n"
+            f"       exports it:\n\n"
+            f"         make all-canister-deploy-local-pytest\n"
+        )
+        return 1
+
     canister_paths = sorted(
         p
         for p in list((ROOT_PATH / "src/icpp/canisters").glob("*"))

--- a/src/icpp/canisters/greet/demo-c++17.sh
+++ b/src/icpp/canisters/greet/demo-c++17.sh
@@ -16,7 +16,9 @@
 # cannot disturb the identity you use for mainnet work.
 ICPP_PRO_TEST_IDENTITY=${ICPP_PRO_TEST_IDENTITY:-greet-testing}
 export ICPP_PRO_TEST_IDENTITY
-icp identity list | grep -qw "$ICPP_PRO_TEST_IDENTITY" || \
+# `icp identity principal` exits non-zero for an unknown name, which is an exact
+# check - unlike grepping `icp identity list`.
+icp identity principal --identity "$ICPP_PRO_TEST_IDENTITY" >/dev/null 2>&1 || \
   icp identity new "$ICPP_PRO_TEST_IDENTITY" --storage plaintext
 
 #######################################################################
@@ -48,15 +50,14 @@ icp deploy --environment local --yes --identity "$ICPP_PRO_TEST_IDENTITY"
 echo " "
 echo "--------------------------------------------------"
 echo "Running some manual tests with icp"
-ID="--environment local --identity $ICPP_PRO_TEST_IDENTITY"
-icp canister call greet greet_0 '()' $ID
-icp canister call greet greet_0_static_lib '()' $ID
-icp canister call greet greet_1 '()' $ID
-icp canister call greet greet_2 '("C++ Developer")' $ID
-icp canister call greet greet_3 '(record { "icpp version" = 1 : int; OS = "Linux" : text })' $ID
-icp canister call greet greet_4 '(record { 6 = 42 : int; 9 = 43 : int }, record { 7 = 44 : int; 10 = 45 : int })' $ID
-icp canister call greet greet_json '("{\"name\": \"AJ\"}")' $ID
-icp canister call greet greet_log_file '()' $ID
+icp canister call greet greet_0 '()' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_0_static_lib '()' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_1 '()' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_2 '("C++ Developer")' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_3 '(record { "icpp version" = 1 : int; OS = "Linux" : text })' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_4 '(record { 6 = 42 : int; 9 = 43 : int }, record { 7 = 44 : int; 10 = 45 : int })' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_json '("{\"name\": \"AJ\"}")' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_log_file '()' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
 
 #######################################################################
 echo " "

--- a/src/icpp/canisters/greet/demo-c++17.sh
+++ b/src/icpp/canisters/greet/demo-c++17.sh
@@ -10,6 +10,16 @@
 #     ./demo.sh
 #
 #######################################################################
+# The identity we deploy with and run the tests as. It is named explicitly and
+# passed to every icp command, so the machine-wide active identity
+# (`icp identity default`) is never read and never changed - running this demo
+# cannot disturb the identity you use for mainnet work.
+ICPP_PRO_TEST_IDENTITY=${ICPP_PRO_TEST_IDENTITY:-greet-testing}
+export ICPP_PRO_TEST_IDENTITY
+icp identity list | grep -qw "$ICPP_PRO_TEST_IDENTITY" || \
+  icp identity new "$ICPP_PRO_TEST_IDENTITY" --storage plaintext
+
+#######################################################################
 echo " "
 echo "--------------------------------------------------"
 echo "Stopping the local network"
@@ -32,20 +42,21 @@ icpp build-wasm --config icpp-c++17.toml --to-compile all
 echo " "
 echo "--------------------------------------------------"
 echo "Deploying the wasm to a canister on the local network"
-icp deploy --environment local --yes
+icp deploy --environment local --yes --identity "$ICPP_PRO_TEST_IDENTITY"
 
 #######################################################################
 echo " "
 echo "--------------------------------------------------"
 echo "Running some manual tests with icp"
-icp canister call greet greet_0 '()' --environment local
-icp canister call greet greet_0_static_lib '()' --environment local
-icp canister call greet greet_1 '()' --environment local
-icp canister call greet greet_2 '("C++ Developer")' --environment local
-icp canister call greet greet_3 '(record { "icpp version" = 1 : int; OS = "Linux" : text })' --environment local
-icp canister call greet greet_4 '(record { 6 = 42 : int; 9 = 43 : int }, record { 7 = 44 : int; 10 = 45 : int })' --environment local
-icp canister call greet greet_json '("{\"name\": \"AJ\"}")' --environment local
-icp canister call greet greet_log_file '()' --environment local
+ID="--environment local --identity $ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_0 '()' $ID
+icp canister call greet greet_0_static_lib '()' $ID
+icp canister call greet greet_1 '()' $ID
+icp canister call greet greet_2 '("C++ Developer")' $ID
+icp canister call greet greet_3 '(record { "icpp version" = 1 : int; OS = "Linux" : text })' $ID
+icp canister call greet greet_4 '(record { 6 = 42 : int; 9 = 43 : int }, record { 7 = 44 : int; 10 = 45 : int })' $ID
+icp canister call greet greet_json '("{\"name\": \"AJ\"}")' $ID
+icp canister call greet greet_log_file '()' $ID
 
 #######################################################################
 echo " "

--- a/src/icpp/canisters/greet/demo.sh
+++ b/src/icpp/canisters/greet/demo.sh
@@ -10,6 +10,16 @@
 #     ./demo.sh
 #
 #######################################################################
+# The identity we deploy with and run the tests as. It is named explicitly and
+# passed to every icp command, so the machine-wide active identity
+# (`icp identity default`) is never read and never changed - running this demo
+# cannot disturb the identity you use for mainnet work.
+ICPP_PRO_TEST_IDENTITY=${ICPP_PRO_TEST_IDENTITY:-greet-testing}
+export ICPP_PRO_TEST_IDENTITY
+icp identity list | grep -qw "$ICPP_PRO_TEST_IDENTITY" || \
+  icp identity new "$ICPP_PRO_TEST_IDENTITY" --storage plaintext
+
+#######################################################################
 echo " "
 echo "--------------------------------------------------"
 echo "Stopping the local network"
@@ -32,20 +42,21 @@ icpp build-wasm --to-compile all
 echo " "
 echo "--------------------------------------------------"
 echo "Deploying the wasm to a canister on the local network"
-icp deploy --environment local --yes
+icp deploy --environment local --yes --identity "$ICPP_PRO_TEST_IDENTITY"
 
 #######################################################################
 echo " "
 echo "--------------------------------------------------"
 echo "Running some manual tests with icp"
-icp canister call greet greet_0 '()' --environment local
-icp canister call greet greet_0_static_lib '()' --environment local
-icp canister call greet greet_1 '()' --environment local
-icp canister call greet greet_2 '("C++ Developer")' --environment local
-icp canister call greet greet_3 '(record { "icpp version" = 1 : int; OS = "Linux" : text })' --environment local
-icp canister call greet greet_4 '(record { 6 = 42 : int; 9 = 43 : int }, record { 7 = 44 : int; 10 = 45 : int })' --environment local
-icp canister call greet greet_json '("{\"name\": \"AJ\"}")' --environment local
-icp canister call greet greet_log_file '()' --environment local
+ID="--environment local --identity $ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_0 '()' $ID
+icp canister call greet greet_0_static_lib '()' $ID
+icp canister call greet greet_1 '()' $ID
+icp canister call greet greet_2 '("C++ Developer")' $ID
+icp canister call greet greet_3 '(record { "icpp version" = 1 : int; OS = "Linux" : text })' $ID
+icp canister call greet greet_4 '(record { 6 = 42 : int; 9 = 43 : int }, record { 7 = 44 : int; 10 = 45 : int })' $ID
+icp canister call greet greet_json '("{\"name\": \"AJ\"}")' $ID
+icp canister call greet greet_log_file '()' $ID
 
 #######################################################################
 echo " "

--- a/src/icpp/canisters/greet/demo.sh
+++ b/src/icpp/canisters/greet/demo.sh
@@ -16,7 +16,9 @@
 # cannot disturb the identity you use for mainnet work.
 ICPP_PRO_TEST_IDENTITY=${ICPP_PRO_TEST_IDENTITY:-greet-testing}
 export ICPP_PRO_TEST_IDENTITY
-icp identity list | grep -qw "$ICPP_PRO_TEST_IDENTITY" || \
+# `icp identity principal` exits non-zero for an unknown name, which is an exact
+# check - unlike grepping `icp identity list`.
+icp identity principal --identity "$ICPP_PRO_TEST_IDENTITY" >/dev/null 2>&1 || \
   icp identity new "$ICPP_PRO_TEST_IDENTITY" --storage plaintext
 
 #######################################################################
@@ -48,15 +50,14 @@ icp deploy --environment local --yes --identity "$ICPP_PRO_TEST_IDENTITY"
 echo " "
 echo "--------------------------------------------------"
 echo "Running some manual tests with icp"
-ID="--environment local --identity $ICPP_PRO_TEST_IDENTITY"
-icp canister call greet greet_0 '()' $ID
-icp canister call greet greet_0_static_lib '()' $ID
-icp canister call greet greet_1 '()' $ID
-icp canister call greet greet_2 '("C++ Developer")' $ID
-icp canister call greet greet_3 '(record { "icpp version" = 1 : int; OS = "Linux" : text })' $ID
-icp canister call greet greet_4 '(record { 6 = 42 : int; 9 = 43 : int }, record { 7 = 44 : int; 10 = 45 : int })' $ID
-icp canister call greet greet_json '("{\"name\": \"AJ\"}")' $ID
-icp canister call greet greet_log_file '()' $ID
+icp canister call greet greet_0 '()' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_0_static_lib '()' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_1 '()' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_2 '("C++ Developer")' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_3 '(record { "icpp version" = 1 : int; OS = "Linux" : text })' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_4 '(record { 6 = 42 : int; 9 = 43 : int }, record { 7 = 44 : int; 10 = 45 : int })' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_json '("{\"name\": \"AJ\"}")' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
+icp canister call greet greet_log_file '()' --environment local --identity "$ICPP_PRO_TEST_IDENTITY"
 
 #######################################################################
 echo " "

--- a/src/icpp/canisters/greet/test/test_apis.py
+++ b/src/icpp/canisters/greet/test/test_apis.py
@@ -2,8 +2,16 @@
 
 First deploy the canister, then run:
 
-$ pytest --network=[local/ic] test_apis.py
+$ pytest --network=[local/ic] --identity <name> test_apis.py
 
+`--identity` names the icp identity the tests call as. Instead of passing it
+every time, export it once:
+
+$ export ICPP_PRO_TEST_IDENTITY=<name>
+
+Deploy with that same identity, so the caller of a test is the controller.
+icpp-pro never uses the machine-wide active identity (`icp identity default`),
+because any other process can change it while the tests are running.
 """
 
 # pylint: disable=missing-function-docstring, unused-import, wildcard-import, unused-wildcard-import, line-too-long
@@ -50,7 +58,8 @@ def test__greet_0_static_lib(network: str) -> None:
 
 # Run this test with anonymous identity
 def test__greet_0_auth_err(identity_anonymous: Dict[str, str], network: str) -> None:
-    # double check the identity_anonymous fixture worked
+    # The identity_anonymous fixture makes every call in this test run as the
+    # anonymous identity, without naming it at the call site.
     assert identity_anonymous["identity"] == "anonymous"
     assert identity_anonymous["principal"] == "2vxsx-fae"
 
@@ -65,17 +74,17 @@ def test__greet_0_auth_err(identity_anonymous: Dict[str, str], network: str) -> 
     assert response == expected_response
 
 
-# Run this test with a logged in default identity
+# Run this test with the identity of the pytest session
 def test__greet_0_auth_ok(identity_default: Dict[str, str], network: str) -> None:
-    # double check the identity_anonymous fixture worked
-    assert identity_default["identity"] == "default"
-
+    # `identity=` names the caller for this one call. identity_default is the
+    # identity the session runs as, so the canister greets its principal.
     response = call_canister_api(
         icp_yaml_path=ICP_YAML_PATH,
         canister_name=CANISTER_NAME,
         canister_method="greet_0_auth",
         canister_argument="()",
         network=network,
+        identity=identity_default["identity"],
     )
     principal = identity_default["principal"]
     expected_response = (

--- a/src/icpp/conftest_base.py
+++ b/src/icpp/conftest_base.py
@@ -1,16 +1,37 @@
 """pytest fixtures provided by icpp-pro
 https://docs.pytest.org/en/latest/fixture.html
+
+Tests run as an identity you name explicitly, either with
+`pytest --identity <name>` or by exporting ICPP_PRO_TEST_IDENTITY. That name is
+passed to every icp command as `--identity <name>`.
+
+The machine-wide active identity (`icp identity default`) is never read and
+never written. It is shared by every process on the machine, so scoping a
+test's identity through it would both clobber the identity you use for mainnet
+work and leave the test at the mercy of anything else that changes it mid-run.
 """
 
+# A fixture that uses another fixture takes it as a parameter of the same name,
+# which is exactly what pylint's redefined-outer-name flags.
+# pylint: disable=redefined-outer-name
+
+import os
 from typing import Any, Generator, Dict
 import pytest
 
 
-from icpp.smoketest import network_status, get_identity, set_identity, get_principal
+from icpp.smoketest import (
+    IDENTITY_ENV_VAR,
+    get_principal,
+    network_status,
+    no_identity_msg,
+    set_identity_override,
+    set_session_identity,
+)
 
 
 def pytest_addoption(parser: Any) -> None:
-    """Adds options: `pytest --network=[local/ic] `"""
+    """Adds options: `pytest --network=[local/ic] --identity=<name>`"""
     parser.addoption(
         "--network",
         action="store",
@@ -18,6 +39,16 @@ def pytest_addoption(parser: Any) -> None:
         help=(
             "The icp.yaml environment to use, eg. local or ic. "
             "It is passed to icp as `--environment`."
+        ),
+    )
+    parser.addoption(
+        "--identity",
+        action="store",
+        default=None,
+        help=(
+            "The icp identity to run the tests as. It is passed to icp as "
+            f"`--identity`. Falls back to ${IDENTITY_ENV_VAR}. Required: "
+            "icpp-pro never uses the machine-wide active identity."
         ),
     )
 
@@ -36,23 +67,42 @@ def network(request: Any) -> Any:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def identity() -> Any:
-    """A fixture that returns the name of the used identity."""
-    identity_ = get_identity()
-    if identity_.startswith("ERROR"):
-        raise RuntimeError(identity_)
+def identity(request: Any) -> Any:
+    """A fixture that pins & returns the identity the tests run as.
+
+    Resolved once, from `--identity` or ${ICPP_PRO_TEST_IDENTITY}, and then
+    passed explicitly to every icp command. Nothing re-reads it, so a change
+    to the machine's active identity mid-run cannot affect the tests.
+    """
+    identity_ = request.config.getoption("--identity") or os.environ.get(
+        IDENTITY_ENV_VAR
+    )
+    if not identity_:
+        pytest.exit(no_identity_msg())
+
+    set_session_identity(identity_)
     return identity_
 
 
 @pytest.fixture(scope="session", autouse=True)
-def principal() -> Any:
-    """A fixture that returns the principal of the used identity."""
-    principal_ = get_principal()
+def principal(identity: str) -> Any:
+    """A fixture that returns the principal of the identity the tests run as.
+
+    Asking for it up front turns a misspelled or password-protected identity
+    into one clear error at session start, instead of an obscure failure in
+    whichever test happens to run first.
+    """
+    principal_ = get_principal(identity=identity)
     if principal_.startswith("ERROR"):
-        if "password" in principal_.lower() or "passphrase" in principal_.lower():
+        # A password-protected identity makes icp prompt. Depending on whether
+        # a terminal is attached, that either says so or simply blocks until
+        # the command times out - so treat both as the same diagnosis.
+        lowered = principal_.lower()
+        if any(s in lowered for s in ("password", "passphrase", "timed out")):
             msg = (
-                f"Identity '{get_identity()}' is password protected. "
-                f"Use an identity created with '--storage plaintext'!"
+                f"Identity '{identity}' looks password protected. icpp-pro "
+                f"exports the key to sign locally, so use an identity created "
+                f"with '--storage plaintext'!\n\n{principal_}"
             )
             raise RuntimeError(msg)
         raise RuntimeError(principal_)
@@ -60,29 +110,31 @@ def principal() -> Any:
 
 
 ####################################################################
-# Fixtures to run a function with the anonymous or default identity
+# Fixtures to run a function with the anonymous or session identity
 
 
-def handle_identity(identity_to_set: str) -> Generator[Dict[str, str], None, None]:
-    """A fixture that sets the icp identity."""
-    identity_before_test = get_identity()
-    set_identity(identity_to_set)
-    user = {"identity": get_identity(), "principal": get_principal()}
-    yield user
-    set_identity(identity_before_test)
+@pytest.fixture(scope="session")
+def identity_default(identity: str, principal: str) -> Dict[str, str]:
+    """A fixture that returns the identity the tests run as.
+
+    Despite the name, this is not an identity literally called `default` - it
+    is the one named by `pytest --identity` or ${ICPP_PRO_TEST_IDENTITY}, which
+    is also the identity the canister was deployed with. The name is kept for
+    backwards compatibility.
+    """
+    return {"identity": identity, "principal": principal}
 
 
 @pytest.fixture(scope="function")
 def identity_anonymous() -> Generator[Dict[str, str], None, None]:
-    """A fixture that sets the icp identity to anonymous."""
-    yield from handle_identity("anonymous")
+    """A fixture that runs a test's canister calls as the anonymous identity.
 
-
-@pytest.fixture(scope="function")
-def identity_default() -> Generator[Dict[str, str], None, None]:
-    """A fixture that sets the icp identity to default.
-
-    Unlike dfx, icp-cli does not create a `default` identity for you. Create
-    it once with: `icp identity new default --storage plaintext`
+    The override lives inside this pytest process, so it is invisible to every
+    other process on the machine and there is nothing to restore if the run is
+    killed.
     """
-    yield from handle_identity("default")
+    set_identity_override("anonymous")
+    try:
+        yield {"identity": "anonymous", "principal": "2vxsx-fae"}
+    finally:
+        set_identity_override(None)

--- a/src/icpp/smoketest.py
+++ b/src/icpp/smoketest.py
@@ -664,23 +664,11 @@ def network_status(
     return response
 
 
-def get_identity() -> str:
-    """Returns the name of the machine-wide active icp identity.
-
-    The test framework itself deliberately never calls this: the active
-    identity is machine-wide, so any other process can change it while a test
-    run is in flight. Tests run as the identity named by `pytest --identity`
-    or the ICPP_PRO_TEST_IDENTITY environment variable instead. Kept as a
-    read-only helper for scripts that genuinely want to report it.
-    """
-    arg = f"{ICP} identity default "
-    try:
-        identity = run_shell_cmd(arg, capture_output=True, timeout_seconds=30)
-        identity = identity.rstrip("\n")
-    except subprocess.CalledProcessError as e:
-        pytest.fail(f"ERROR: command {arg} failed with error:\n{e.output}")
-
-    return identity
+# There is deliberately no `get_identity()`. It returned the machine-wide
+# active identity (`icp identity default`), which every other process on the
+# machine can change at any moment - so anything derived from it, including
+# `identity=get_identity()`, is a race. Run `icp identity default` in a shell
+# if you want to report it.
 
 
 def get_principal(identity: Optional[str] = None) -> str:

--- a/src/icpp/smoketest.py
+++ b/src/icpp/smoketest.py
@@ -13,10 +13,19 @@ environment per network you test against, e.g.:
         network: ic
 
 so that `pytest --network=local` and `pytest --network=ic` keep working.
+
+The identity every helper calls as is named explicitly, with
+`pytest --identity <name>` or by exporting ICPP_PRO_TEST_IDENTITY, and is
+passed to icp as `--identity <name>`. Pass `identity=` to override it for a
+single call. The machine-wide active identity (`icp identity default`) is never
+read and never written: it is shared with every other process on the machine,
+so using it would clobber the identity you use for mainnet work and leave a run
+exposed to anything that changes it mid-flight.
 """
 
 import json
 import re
+import shlex
 import subprocess
 import warnings
 from pathlib import Path
@@ -27,6 +36,10 @@ import yaml
 from icpp.run_shell_cmd import run_shell_cmd
 
 ICP = "icp"
+
+# Names the identity the tests run as, when `pytest --identity <name>` is not
+# given.
+IDENTITY_ENV_VAR = "ICPP_PRO_TEST_IDENTITY"
 
 # dfx's `--type` / `--output` values, mapped onto the icp-cli equivalents
 # (`--args-format` / `--output`). The icp-cli names are passed through, so
@@ -47,6 +60,68 @@ _OUTPUT_FORMATS = {
     "text": "text",
     "auto": "auto",
 }
+
+
+# The identity every icp command runs as. This state is deliberately
+# process-local: `icp identity default <name>` is machine-wide and persistent,
+# so using it to scope an identity to a test would mutate the developer's
+# machine - and any other process could change it again mid-run.
+_SESSION_IDENTITY: Optional[str] = None
+_IDENTITY_OVERRIDE: Optional[str] = None
+
+
+def set_session_identity(name: str) -> None:
+    """Pins the identity for this pytest process. Set once, from a fixture."""
+    global _SESSION_IDENTITY  # pylint: disable=global-statement
+    _SESSION_IDENTITY = name
+
+
+def set_identity_override(name: Optional[str]) -> None:
+    """Overrides the session identity for one test. `None` clears it."""
+    global _IDENTITY_OVERRIDE  # pylint: disable=global-statement
+    _IDENTITY_OVERRIDE = name
+
+
+def _available_identities() -> str:
+    """The output of `icp identity list`, to show in an error message."""
+    try:
+        return run_shell_cmd(
+            f"{ICP} identity list", capture_output=True, timeout_seconds=30
+        ).rstrip("\n")
+    except subprocess.CalledProcessError:
+        return "    (could not run `icp identity list`)"
+
+
+def no_identity_msg() -> str:
+    """The 'name your test identity' message, when none has been configured."""
+    return (
+        "\n\n"
+        "ERROR: no test identity configured.\n\n"
+        "icpp-pro never uses the machine-wide active identity\n"
+        "(`icp identity default`), because any other process can change it\n"
+        "while your tests are running.\n\n"
+        "Name the identity explicitly:\n\n"
+        "    pytest --network=local --identity <name>\n\n"
+        "or, once per project:\n\n"
+        f"    export {IDENTITY_ENV_VAR}=<name>\n\n"
+        "Create one with:\n\n"
+        "    icp identity new <name> --storage plaintext\n\n"
+        "(icpp-pro exports the key to sign locally, so the identity must not\n"
+        " be password protected.)\n\n"
+        "Available identities:\n"
+        f"{_available_identities()}\n"
+    )
+
+
+def _identity() -> str:
+    """The identity to run an icp command as.
+
+    Never reads `icp identity default` - see the comment on _SESSION_IDENTITY.
+    """
+    name = _IDENTITY_OVERRIDE or _SESSION_IDENTITY
+    if name is None:
+        pytest.fail(no_identity_msg())
+    return name
 
 
 def _icp_yaml(
@@ -202,6 +277,7 @@ def _candid_text(
     canister_name: str,
     network: str,
     timeout_seconds: Optional[int],
+    identity: str,
 ) -> Optional[str]:
     """Returns the canister's Candid interface, or None if it cannot be found.
 
@@ -229,6 +305,7 @@ def _candid_text(
                 f" --environment {network} ",
                 project_root,
                 timeout_seconds,
+                identity=identity,
             )
         except subprocess.CalledProcessError:
             did_text = None
@@ -255,13 +332,21 @@ def _run_icp(
     args: str,
     project_root: Optional[Path] = None,
     timeout_seconds: Optional[int] = None,
+    identity: Optional[str] = None,
 ) -> str:
     """Runs an icp command against a project & returns its captured output.
 
     Without a `project_root`, icp finds the project itself by walking up from
     the current working directory.
+
+    `identity` is appended as `--identity <name>`. Pass it only for
+    subcommands that accept it: `canister call`, `canister metadata`,
+    `canister status` and `deploy` do, `network ping` and `network status`
+    do not.
     """
     cmd = f"{ICP} {args} "
+    if identity is not None:
+        cmd += f"--identity {shlex.quote(identity)} "
     if project_root is not None:
         cmd += f"--project-root-override {str(project_root)} "
     # icp launches an interactive prompt when it is missing an argument. Close
@@ -285,9 +370,15 @@ def call_canister_api(
     query: Optional[bool] = None,
     quiet: str = "-qq",  # deprecated: dfx only, icp-cli has no verbosity flag
     timeout_seconds: Optional[int] = None,
+    identity: Optional[str] = None,
     dfx_json_path: Optional[Path] = None,  # deprecated alias of icp_yaml_path
 ) -> str:
     """Calls a canister method.
+
+    `identity` names the icp identity to call as. It defaults to the identity
+    of the pytest session (`pytest --identity <name>` or the
+    ICPP_PRO_TEST_IDENTITY environment variable), which the
+    `identity_anonymous` fixture temporarily overrides.
 
     `query` selects the request type:
 
@@ -304,6 +395,8 @@ def call_canister_api(
     """
     del quiet  # accepted for backwards compatibility, has no icp-cli equivalent
 
+    identity = identity or _identity()
+
     icp_yaml = _verify_canister_name(canister_name, icp_yaml_path, dfx_json_path)
     project_root = icp_yaml.parent
 
@@ -318,7 +411,7 @@ def call_canister_api(
 
     if query is None:
         did_text = _candid_text(
-            project_root, icp_yaml, canister_name, network, timeout_seconds
+            project_root, icp_yaml, canister_name, network, timeout_seconds, identity
         )
         query = bool(
             did_text is not None and _is_query_in_did(did_text, canister_method)
@@ -337,7 +430,7 @@ def call_canister_api(
         arg += " --query "
 
     try:
-        response = _run_icp(arg, project_root, timeout_seconds)
+        response = _run_icp(arg, project_root, timeout_seconds, identity=identity)
     except subprocess.CalledProcessError as e:
         if _is_not_deployed_error(e.output):
             pytest.exit(_not_deployed_msg(canister_name, network, canister_method))
@@ -356,6 +449,7 @@ def get_canister_url(
     network: str = "local",
     url_path: Optional[str] = None,
     timeout_seconds: Optional[int] = None,
+    identity: Optional[str] = None,
     dfx_json_path: Optional[Path] = None,  # deprecated alias of icp_yaml_path
 ) -> str:
     """THIS FUNCTION IS DEPRECATED. DO NOT USE...
@@ -372,6 +466,7 @@ def get_canister_url(
         canister_name=canister_name,
         network=network,
         timeout_seconds=timeout_seconds,
+        identity=identity,
     )
 
     if network == "ic":
@@ -403,6 +498,7 @@ def get_canister_url_with_headers(
     network: str = "local",
     url_path: Optional[str] = None,
     timeout_seconds: Optional[int] = None,
+    identity: Optional[str] = None,
     dfx_json_path: Optional[Path] = None,  # deprecated alias of icp_yaml_path
 ) -> Tuple[str, Optional[Dict[str, str]]]:
     """Returns the url + headers for calling a canister as a Web2.0 HTTP server"""
@@ -413,6 +509,7 @@ def get_canister_url_with_headers(
         canister_name=canister_name,
         network=network,
         timeout_seconds=timeout_seconds,
+        identity=identity,
     )
 
     # The `raw` subdomain bypasses response certification, which an icpp-pro
@@ -445,6 +542,7 @@ def get_canister_id(
     icp_yaml_path: Optional[Path] = None,
     network: str = "local",
     timeout_seconds: Optional[int] = None,
+    identity: Optional[str] = None,
     dfx_json_path: Optional[Path] = None,  # deprecated alias of icp_yaml_path
 ) -> str:
     """Returns the canister_id of a canister"""
@@ -471,6 +569,7 @@ def get_canister_id(
             f" canister status {canister_name} --environment {network} --json ",
             project_root,
             timeout_seconds,
+            identity=identity or _identity(),
         )
     except subprocess.CalledProcessError as e:
         if _is_not_deployed_error(e.output):
@@ -566,7 +665,14 @@ def network_status(
 
 
 def get_identity() -> str:
-    """Returns the name of the current icp identity."""
+    """Returns the name of the machine-wide active icp identity.
+
+    The test framework itself deliberately never calls this: the active
+    identity is machine-wide, so any other process can change it while a test
+    run is in flight. Tests run as the identity named by `pytest --identity`
+    or the ICPP_PRO_TEST_IDENTITY environment variable instead. Kept as a
+    read-only helper for scripts that genuinely want to report it.
+    """
     arg = f"{ICP} identity default "
     try:
         identity = run_shell_cmd(arg, capture_output=True, timeout_seconds=30)
@@ -577,18 +683,15 @@ def get_identity() -> str:
     return identity
 
 
-def set_identity(identity: str) -> None:
-    """Sets the icp identity."""
-    arg = f"{ICP} identity default {identity}"
-    try:
-        run_shell_cmd(arg)
-    except subprocess.CalledProcessError as e:
-        pytest.fail(f"ERROR: command {arg} failed with error:\n{e.output}")
+def get_principal(identity: Optional[str] = None) -> str:
+    """Returns the principal of an identity, without changing anything.
 
-
-def get_principal() -> str:
-    """Returns the principal of the current icp identity."""
-    arg = f"{ICP} identity principal "
+    Defaults to the identity of the pytest session. `icp identity principal`
+    is asked for it by name, so the machine-wide active identity is neither
+    read nor written.
+    """
+    name = identity or _identity()
+    arg = f"{ICP} identity principal --identity {shlex.quote(name)} "
     try:
         principal = run_shell_cmd(arg, capture_output=True, timeout_seconds=30)
         principal = principal.rstrip("\n")

--- a/src/icpp/version.py
+++ b/src/icpp/version.py
@@ -10,4 +10,4 @@ see:
 https://packaging.python.org/guides/single-sourcing-package-version/
 """
 
-__version__ = "5.6.0"
+__version__ = "6.0.0"

--- a/test/canisters/canister_1/test/test_apis.py
+++ b/test/canisters/canister_1/test/test_apis.py
@@ -641,7 +641,8 @@ def test__roundtrip_principal(network: str, principal: str) -> None:
 def test__caller_is_anonymous_true(
     identity_anonymous: Dict[str, str], network: str
 ) -> None:
-    # double check the identity_anonymous fixture worked
+    # The identity_anonymous fixture makes every call in this test run as the
+    # anonymous identity, without naming it at the call site.
     assert identity_anonymous["identity"] == "anonymous"
     assert identity_anonymous["principal"] == "2vxsx-fae"
 
@@ -659,15 +660,15 @@ def test__caller_is_anonymous_true(
 def test__caller_is_anonymous_false(
     identity_default: Dict[str, str], network: str
 ) -> None:
-    # double check the identity_default fixture worked
-    assert identity_default["identity"] == "default"
-
+    # `identity=` names the caller for this one call. identity_default is the
+    # identity the session runs as, which is never anonymous.
     response = call_canister_api(
         icp_yaml_path=ICP_YAML_PATH,
         canister_name=CANISTER_NAME,
         canister_method="caller_is_anonymous",
         canister_argument="()",
         network=network,
+        identity=identity_default["identity"],
     )
     expected_response = "(false)"
     assert response == expected_response
@@ -676,12 +677,15 @@ def test__caller_is_anonymous_false(
 def test__caller_is_controller_true(
     identity_default: Dict[str, str], network: str
 ) -> None:
+    # The canister is deployed with the session identity, so that identity is
+    # its controller.
     response = call_canister_api(
         icp_yaml_path=ICP_YAML_PATH,
         canister_name=CANISTER_NAME,
         canister_method="caller_is_controller",
         canister_argument="()",
         network=network,
+        identity=identity_default["identity"],
     )
     expected_response = "(true)"
     assert response == expected_response
@@ -690,6 +694,7 @@ def test__caller_is_controller_true(
 def test__caller_is_controller_false(
     identity_anonymous: Dict[str, str], network: str
 ) -> None:
+    # Runs as anonymous, via the fixture - see test__caller_is_anonymous_true.
     response = call_canister_api(
         icp_yaml_path=ICP_YAML_PATH,
         canister_name=CANISTER_NAME,


### PR DESCRIPTION
**Breaking change (6.0.0).** Tests must now be told which icp identity to run as, with
`pytest --identity <name>` or by exporting `ICPP_PRO_TEST_IDENTITY`. That name is passed to
every icp command as `--identity`. `icp identity default` is never read and never written.

## The problem

`conftest_base.handle_identity()` ran `icp identity default <name>`, which is **machine-wide
and persistent**, then restored it after `yield`.

`Makefile:89` was worse: `icp identity default default` was a prerequisite of
`all-canister-deploy-local-pytest`, so `make all-tests` repointed the machine default
permanently, with no restore at all. The same two commands were in
`README-contributors-guide.md` and `README-release-guide.md`.

Four consequences, of which the last is the reason this is a major release:

1. The restore was ordinary code after a `yield`, so `Ctrl-C` / a timeout kill / `SIGKILL`
   left the default pointing at `default` -- or at `anonymous`, which is worse, because an
   anonymous principal is rejected by almost everything with errors that never mention
   identity.
2. It leaked outside the test session: anything else reading the default mid-run saw the
   wrong identity.
3. It could not run in parallel -- one global setting, no lock.
4. **Another process could change it while the tests ran.** Save-and-restore cannot fix this.
   Every call resolved the default *at call time*, so a `make` target in another checkout, or
   another agent, silently changed who the tests were calling as.

## The fix

One identity, named explicitly, resolved once at session start and passed to every icp
command that accepts `--identity`. Nothing re-reads it.

- **`smoketest.py`** -- process-local `_SESSION_IDENTITY` / `_IDENTITY_OVERRIDE` with
  `set_session_identity()` / `set_identity_override()`, and a keyword-only `identity=` on
  `call_canister_api`, `get_canister_id`, `get_principal`, `_candid_text` and the url helpers.
  `_run_icp` appends `--identity`, per call site: `network ping` / `network status` reject the
  flag. `set_identity()` is deleted; `get_identity()` stays as an uncalled read-only helper.
- **`conftest_base.py`** -- `--identity` option, falling back to `$ICPP_PRO_TEST_IDENTITY`,
  hard-erroring otherwise with a message that lists the available identities.
  `identity_default` yields the pinned identity; `identity_anonymous` sets a process-local
  override in a `try/finally`; `handle_identity` is gone.
- **`Makefile` / `scripts/`** -- `icp identity default default` deleted. The Makefile creates
  and exports `icpp-pro-testing`; the deploy passes `--identity` so the caller of a test is
  the canister's controller.
- Docs, both `greet` demo scripts, the shipped template and the version follow.

## Verification

The load-bearing one -- with a suite in flight, the machine default was flipped to
`anonymous` and then to `default` from another process, and all 127 `canister_1` tests still
passed. Before this change that would have broken the run.

- `make all-tests` green: all 7 canisters PASSED.
- `icp identity default` read `icpp-llm` before, during and after every run, including a
  `kill -9` mid-test.
- `env -u ICPP_PRO_TEST_IDENTITY pytest` exits with the "no test identity configured" message
  rather than guessing.
- Negative control: `pytest --identity anonymous` makes `caller_is_anonymous_false` and
  `caller_is_controller_true` fail, proving `identity=` is wired through and not decorative.
- pylint 10.00/10, mypy strict clean, no `icp identity default <name>` left in the repo.

## Migrating

One line per project: `export ICPP_PRO_TEST_IDENTITY=<name>`, plus `--identity` on `icp
deploy`. Across all downstream repos exactly one test asserts the literal name and needs a
one-line edit. Docs PR: icppWorld/icpp-docs#1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tests and deployments now support explicitly selected identities without changing the machine-wide default identity.
  * Demo scripts automatically create or reuse dedicated identities for deployment and canister calls.
  * Added clearer errors for missing, protected, or unavailable identities.

* **Documentation**
  * Updated contributor, release, and testing guides with the new identity workflow and commands.

* **Refactor**
  * Improved identity handling across test and canister operations, including anonymous and authenticated scenarios.

* **Chores**
  * Updated the package version to 6.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->