### PR TITLE
Cancel superseded CI runs with a concurrency group

### DIFF
--- a/.github/workflows/cicd-mac.yml
+++ b/.github/workflows/cicd-mac.yml
@@ -13,6 +13,15 @@ on:
       - ".github/trigger.txt"
       - ".github/workflows/cicd-mac.yml"
 
+# A new push to the same branch makes the in-flight matrix irrelevant, and
+# GitHub does not cancel it for us. That is not just waste: the macOS runner
+# pool is small, so a superseded run keeps holding runners and the new one sits
+# queued behind it. `main` is excluded, because the release process pushes a
+# version commit there and needs that run to complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   all-mac:
     name: all-mac

--- a/.github/workflows/cicd-ubuntu.yml
+++ b/.github/workflows/cicd-ubuntu.yml
@@ -13,6 +13,13 @@ on:
       - ".github/trigger.txt"
       - ".github/workflows/cicd-ubuntu.yml"
 
+# Cancel a superseded run - see the comment in cicd-mac.yml. `main` is
+# excluded, because the release process needs each version commit's run to
+# complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   all-ubuntu:
     name: all-ubuntu

--- a/.github/workflows/cicd-wheel-test.yml
+++ b/.github/workflows/cicd-wheel-test.yml
@@ -18,6 +18,13 @@ on:
       - "pyproject.toml"
       - ".github/workflows/cicd-wheel-test.yml"
 
+# Cancel a superseded run - see the comment in cicd-mac.yml. `main` is
+# excluded, because the release process needs each version commit's run to
+# complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   wheel-test:
     name: wheel-test


### PR DESCRIPTION
Pushing to a branch does not cancel the previous run, so a superseded matrix keeps going.
That is not just wasted minutes: the macOS runner pool is small, so the stale run holds
runners and the new one sits queued behind it. This happened during #51 — the mac matrix on
the superseded commit had to be cancelled by hand before the new one could start.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

Added to all three workflows.

## Why `main` is excluded

Not the usual `cancel-in-progress: true`. The release process pushes a version commit to
`main` and then waits on its CI before publishing. With unconditional cancellation, a second
push to `main` — say a `pyproject.toml` dependency bump landing right after the version
commit, which is exactly what 6.0.0 did — would silently kill the run being waited on.

Superseded *branch* runs are waste. Superseded *main* runs are release evidence.

## Verified

All three files parse with `yaml.safe_load`, and each workflow lists its own path in its
trigger filter, so this PR exercises the new config on itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow efficiency by automatically canceling superseded runs on non-main branches.
  * Main branch and release-related runs continue to complete without cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->